### PR TITLE
Include PKAPI in non-default export

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -885,6 +885,8 @@ class PKAPI {
 
 export default PKAPI;
 export {
+	PKAPI,
+	
 	APIError,
 
 	Group,


### PR DESCRIPTION
This allows people to do
```ts
import { PKAPI, /*other things*/ } from "pkapi.js"
```