### PR TITLE
fix: make system prop optional on IMember/Member

### DIFF
--- a/lib/structures/member.ts
+++ b/lib/structures/member.ts
@@ -178,7 +178,7 @@ export interface ProxyTag {
 export interface IMember {
 	id: string;
 	uuid: string;
-	system: string;
+	system?: string;
 	name: string;
 	display_name?: string;
 	color?: string;
@@ -208,7 +208,7 @@ export default class Member implements IMember {
 
 	id: string = '';
 	uuid: string = '';
-	system: string = '';
+	system?: string = '';
 	name: string = '';
 	display_name?: string;
 	color?: string;


### PR DESCRIPTION
To be consistent with IGroup/Group in commit c03f746 (not sure if this is a backwards compatibility break, possibly?)

Also, we're defining system as optional in Member/Group, but we always default it to an empty string `system?: string = '';` so it's always gonna be defaulted to an empty string if missing in the API response.

Also being preset in `KEYS` means we always set the property to undefined rather than the property not existing so technically it'd be `string | undefined` on Member/Group rather than an optional prop.

Either way, this makes Member/Group consistent, but not really consistent with the API's behaviour, whether that's an issue is a separate question.