### PR TITLE
fix: actually pass token to api in getGroupMembers

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -568,7 +568,7 @@ class PKAPI {
 		if(!data.group) throw new Error("Must provide a group ID.");
 
 		try {
-			var resp = await this.handle(ROUTES[this.#_version].GET_GROUP_MEMBERS(data.group));
+			var resp = await this.handle(ROUTES[this.#_version].GET_GROUP_MEMBERS(data.group), { token });
 		} catch(e) {
 			throw e;
 		}


### PR DESCRIPTION
Whaddup it's your favorite gal with another bugfix :3

The user's token was never passed to the API in `getGroupMembers` this fixes that