### PR TITLE
Make .d.ts files discoverable from the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,14 @@
   "module": "./dist/esm/index.mjs",
   "exports": {
     ".": {
-      "require": "./dist/cjs/index.js",
-      "import": "./dist/esm/index.mjs"
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      },
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.mjs"
+      }
     }
   },
   "dependencies": {


### PR DESCRIPTION
It seems that when typescript is configured with `"module": "NodeNext"`, it becomes unable to find `.d.ts` files that were not advertised within the `package.json`'s `"exports"` field, making it return an error when trying to use `pkapi.js`.

This PR fixes that issue, by employing the arguably janky and [seeminly only documented in patch notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing) support from TypeScript for the `"exports"` field.
Note that the `"types"` and `"default"` paths must come in this order.

I would mark this as a minor version bump, since a new "feature" (here the discoverability of the typing information through the `package.json` `"exports"` field) is added, that should (according to [the specification of the `"exports"` field](https://nodejs.org/api/packages.html#package-entry-points)) not be breaking any setup relying on the previous configuration.

Lastly, I would like to say thank you for making and maintaining this library! :heart: