### PR TITLE
remove trailing whitespace and consistently use tabs instead of spaces

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -54,7 +54,7 @@ class PKAPI {
 	#debug: boolean = true;
 
 	#version_warning = false;
-	
+
 	constructor(data?: APIData) {
 		this.#_base = (data?.base_url ?? 'https://api.pluralkit.me');
 		this.#_version = (data?.version ?? 2);
@@ -66,7 +66,7 @@ class PKAPI {
 			validateStatus: (s) => s < 300 && s > 100,
 			baseURL: `${this.#_base}/v${this.#_version}`,
 			headers: {
-				'User-Agent': this.#user_agent 
+				'User-Agent': this.#user_agent
 			}
 		})
 	}
@@ -74,7 +74,7 @@ class PKAPI {
 	/*
 	**			SYSTEM FUNCTIONS
 	*/
-	
+
 	async getSystem(data: GetSystemOptions = { }) {
 		var token = this.#token ?? data.token;
 		if(data.system == null && !token) throw new Error('Must provide a token or ID.');
@@ -251,7 +251,7 @@ class PKAPI {
 		return new Member(this, resp.data);
 	}
 
-	async getMember(data: { token?: string, member: string  }) {
+	async getMember(data: { token?: string, member: string	}) {
 		if(data.member == null) throw new Error('Must provide a member ID.');
 		var token = this.#token || data.token;
 		try {
@@ -547,7 +547,7 @@ class PKAPI {
 
 	async deleteGroup(data: { token?: string, group: string }) {
 		if(this.version < 2) throw new Error("Groups are only available for API version 2.");
-		
+
 		if(data.group == null) throw new Error("Must provide a group ID.");
 		var token = this.#token || data.token;
 		if(!token) throw new Error("DELETE requires a token.");
@@ -674,7 +674,7 @@ class PKAPI {
 
 		if(data.members) {
 			if(Array.isArray(data.members)) {
-				body.members = data.members;	
+				body.members = data.members;
 			} else {
 				body.members = Object.values(data.members).map((m: IMember) => m.id);
 			}
@@ -888,7 +888,7 @@ class PKAPI {
 
 		if(options?.body) {
 			request.headers["content-type"] = "application/json";
-	        request.data = JSON.stringify(options.body);
+			request.data = JSON.stringify(options.body);
 		}
 
 		if(this.version == 1 && !this.#version_warning) {
@@ -900,7 +900,7 @@ class PKAPI {
 			);
 			this.#version_warning = true;
 		}
-			
+
 		try {
 			var resp = await this.#inst(route, request);
 		} catch(e: any) {
@@ -910,7 +910,7 @@ class PKAPI {
 
 		return resp;
 	}
-	
+
 	set base_url(s) {
 		this.#_base = s;
 		this.#inst.defaults.baseURL = `${this.#_base}/v${this.#_version}`;
@@ -958,7 +958,7 @@ class PKAPI {
 export default PKAPI;
 export {
 	PKAPI,
-	
+
 	APIError,
 
 	Group,

--- a/lib/structures/group.ts
+++ b/lib/structures/group.ts
@@ -128,7 +128,7 @@ export default class Group implements IGroup {
 	created: Date | string = '';
 	privacy: GroupPrivacy = {};
 	members?: Map<string, Member> | Array<string>;
-	
+
 	constructor(api: API, data: Partial<Group>) {
 		this.#api = api;
 		for(var k in data) {
@@ -184,7 +184,7 @@ export default class Group implements IGroup {
 				errors.push(`Key ${k} is required, but wasn't supplied`);
 				continue;
 			}
-			
+
 			if(this[k] == null) {
 				group[k] = this[k];
 				continue;

--- a/lib/structures/member.ts
+++ b/lib/structures/member.ts
@@ -229,7 +229,7 @@ export default class Member implements IMember {
 
 	groups?: Map<string, Group>;
 	settings?: Map<string, MemberGuildSettings>;
-	
+
 	constructor(api: API, data: Partial<Member>) {
 		this.#api = api;
 		for(var k in data) {
@@ -292,7 +292,7 @@ export default class Member implements IMember {
 				errors.push(`Key ${k} is required, but wasn't supplied`);
 				continue;
 			}
-			
+
 			if(this[k] == null) {
 				mem[k] = this[k];
 				continue;

--- a/lib/structures/memberGuildSettings.ts
+++ b/lib/structures/memberGuildSettings.ts
@@ -72,7 +72,7 @@ export default class MemberGuildSettings implements IMemberGuildSettings {
 				continue;
 			}
 			if(this[k] == undefined) continue;
-			
+
 			if(KEYS[k].test) test = await KEYS[k].test(this[k]);
 			if(!test) {
 				errors.push(KEYS[k].err);

--- a/lib/structures/switch.ts
+++ b/lib/structures/switch.ts
@@ -34,7 +34,7 @@ export default class Switch implements ISwitch {
 	id: string = '';
 	timestamp: Date | string = '';
 	members?: Map<string, Member> | Array<string>;
-	
+
 	constructor(api: API, data: Partial<Switch>) {
 		this.#api = api;
 		if(!data.timestamp || !data.members)
@@ -73,7 +73,7 @@ export default class Switch implements ISwitch {
 				continue;
 			}
 			if(this[k] == undefined) continue;
-			
+
 			var test = true;
 			if(KEYS[k].test) test = await KEYS[k].test(this[k]);
 			if(!test) {

--- a/lib/structures/system.ts
+++ b/lib/structures/system.ts
@@ -133,7 +133,7 @@ export default class System implements ISystem {
 	settings?: Map<string, SystemGuildSettings>;
 	config?: SystemConfig;
 	autoproxySettings?: Map<string, SystemAutoproxyConfig>;
-	
+
 	constructor(api: API, data: Partial<System>) {
 		this.#api = api;
 		for(var k in data) {
@@ -254,7 +254,7 @@ export default class System implements ISystem {
 				continue;
 			}
 			if(this[k] == undefined) continue;
-			
+
 			if(KEYS[k].test) test = await KEYS[k].test(this[k]);
 			if(!test) {
 				errors.push(KEYS[k].err);

--- a/lib/structures/systemAutoproxySettings.ts
+++ b/lib/structures/systemAutoproxySettings.ts
@@ -69,7 +69,7 @@ export default class SystemAutoproxySettings implements ISystemAutoproxySettings
 				continue;
 			}
 			if(this[k] == undefined) continue;
-			
+
 			if(KEYS[k].test) test = await KEYS[k].test(this[k]);
 			if(!test) {
 				errors.push(KEYS[k].err);

--- a/lib/structures/systemConfig.ts
+++ b/lib/structures/systemConfig.ts
@@ -93,7 +93,7 @@ export default class SystemConfig implements ISystemConfig {
 				continue;
 			}
 			if(this[k] == undefined) continue;
-			
+
 			if(KEYS[k].test) test = await KEYS[k].test(this[k]);
 			if(!test) {
 				errors.push(KEYS[k].err);

--- a/lib/structures/systemGuildSettings.ts
+++ b/lib/structures/systemGuildSettings.ts
@@ -47,7 +47,7 @@ export default class SystemGuildSettings implements ISystemGuildSettings {
 	[key: string]: any;
 
 	#api: API;
-	
+
 	guild = '';
 	proxying_enabled?: boolean;
 	tag?: string | null;
@@ -81,7 +81,7 @@ export default class SystemGuildSettings implements ISystemGuildSettings {
 				continue;
 			}
 			if(this[k] == undefined) continue;
-			
+
 			if(KEYS[k].test) test = await KEYS[k].test(this[k]);
 			if(!test) {
 				errors.push(KEYS[k].err);

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -9,7 +9,7 @@ export function validatePrivacy(keys: Array<string>, obj: any) {
 
 		priv[k] = obj[k] ? 'public' : 'private';
 	}
-	
+
 	return priv;
 }
 


### PR DESCRIPTION
A bunch of lines had trailing whitespace, and a bunch of files had mixed use of tabs and spaces.

This PR fixes both