### PR TITLE
refactor: remove redundant try-catch statements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*.json]
+indent_size = 2
+indent_style = space
+
+[*.ts]
+indent_style = tab
+indent_size = 2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,16 @@ jobs:
       - run: npm ci
       - run: npm run build
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run lint
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,16 @@ jobs:
       - run: npm ci
       - run: npm run lint
 
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run check
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.prettierrc.toml
+++ b/.prettierrc.toml
@@ -1,0 +1,3 @@
+singleQuote = true
+semi = true
+trailingComma = "all"

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -3,5 +3,6 @@ const { createDefaultPreset } = require('ts-jest');
 /** @type {import("jest").Config} **/
 module.exports = {
 	testMatch: ['<rootDir>/lib/__tests__/**/*.test.ts'],
+	setupFilesAfterEnv: ['<rootDir>/lib/__tests__/testSetup.ts'],
 	...createDefaultPreset(),
 };

--- a/lib/RateLimiter/DefaultRateLimiter.ts
+++ b/lib/RateLimiter/DefaultRateLimiter.ts
@@ -56,9 +56,7 @@ export default class DefaultRateLimiter extends BaseRateLimiter {
 	private adjustWaitTime() {
 		const curTime = Date.now();
 		this.errorTimestamps = this.errorTimestamps.filter(
-			(v) =>
-				v >
-				curTime - this.options.errorWindowBase * this.options.minWait,
+			(v) => v > curTime - this.options.errorWindowBase * this.options.minWait,
 		);
 
 		// If we hit the rate limit more than `increaseThreshold` times
@@ -102,8 +100,7 @@ export default class DefaultRateLimiter extends BaseRateLimiter {
 			return null;
 		}
 
-		const parsed: { limit?: number; remaining?: number; reset?: number } =
-			{};
+		const parsed: { limit?: number; remaining?: number; reset?: number } = {};
 
 		if ('x-ratelimit-limit' in headers) {
 			if (typeof headers['x-ratelimit-limit'] == 'string') {

--- a/lib/RateLimiter/DefaultRateLimiter.ts
+++ b/lib/RateLimiter/DefaultRateLimiter.ts
@@ -174,14 +174,13 @@ export default class DefaultRateLimiter extends BaseRateLimiter {
 	}
 
 	public async handleError(error: unknown): Promise<boolean> {
-		if (
-			axios.isAxiosError(error) &&
-			error.response &&
-			this.isRateLimitError(error.response)
-		) {
-			this.errorTimestamps.push(Date.now());
+		if (axios.isAxiosError(error) && error.response) {
+			if (this.isRateLimitError(error.response)) {
+				this.errorTimestamps.push(Date.now());
+			}
+
 			this.handleResult(error.response);
-			return true;
+			return this.isRateLimitError(error.response);
 		}
 
 		return false;

--- a/lib/__tests__/RateLimiter/DefaultRateLimiter.test.ts
+++ b/lib/__tests__/RateLimiter/DefaultRateLimiter.test.ts
@@ -2,7 +2,7 @@ import { jest, describe, expect, it } from '@jest/globals';
 
 import DefaultRateLimiter from '../../RateLimiter/DefaultRateLimiter';
 
-import { createRateLimitError, createResponse } from './util';
+import { createAxiosError, createResponse } from './util';
 
 class TestRateLimiter extends DefaultRateLimiter {
 	public setErrorTimestamps(timestamps: Array<number>) {
@@ -10,7 +10,7 @@ class TestRateLimiter extends DefaultRateLimiter {
 	}
 
 	public async triggerError() {
-		return this.handleError(createRateLimitError());
+		return this.handleError(createAxiosError());
 	}
 
 	public getWaitTime() {
@@ -73,7 +73,7 @@ describe('DefaultRateLimiter', function () {
 			expect(limiter.getWaitTime()).toBe(1000);
 		});
 	});
-	describe('take', function () {
+	describe('wait', function () {
 		it("waits if there's no remaining requests", async function () {
 			jest.useFakeTimers();
 
@@ -88,16 +88,7 @@ describe('DefaultRateLimiter', function () {
 				}),
 			);
 
-			// set done to true after the wait time
-			let done = false;
-			const limiterPromise = limiter.wait().then(() => (done = true));
-			// make sure the short circuit case resolves, so we can test correctly
-			await jest.advanceTimersByTimeAsync(0);
-
-			expect(done).toBe(false);
-			await jest.advanceTimersByTimeAsync(1000);
-			await limiterPromise; // wait for the promise
-			expect(done).toBe(true);
+			await expect(limiter.wait()).toResolveAfterAtLeast(1000);
 		});
 		it('waits if a rate limit error was triggered', async function () {
 			jest.useFakeTimers();
@@ -106,28 +97,12 @@ describe('DefaultRateLimiter', function () {
 			// trigger an error to ratelimit the next request
 			await limiter.triggerError();
 
-			// set done to true after waiting for the ratelimiter
-			let done = false;
-			limiter.wait().then(() => (done = true));
-
-			// after 500 milliseconds we should still be waiting as our waitTime is 1000
-			await jest.advanceTimersByTimeAsync(500);
-			expect(done).toBe(false);
-
-			// after a second we should be done
-			await jest.advanceTimersByTimeAsync(500);
-			expect(done).toBe(true);
+			await expect(limiter.wait()).toResolveAfterAtLeast(1000);
 		});
 		it("immediately returns if there's no ratelimiting", async function () {
 			jest.useFakeTimers();
-
 			const limiter = new TestRateLimiter({ initialWaitTime: 1000 });
-			// set done to true after waiting for the ratelimiter
-			let done = false;
-			limiter.wait().then(() => (done = true));
-
-			await jest.advanceTimersByTimeAsync(0);
-			expect(done).toBe(true);
+			await expect(limiter.wait()).toResolveAfterAtLeast(0);
 		});
 		it('respects x-ratelimit-reset headers from API responses', async function () {
 			jest.useFakeTimers();
@@ -142,65 +117,48 @@ describe('DefaultRateLimiter', function () {
 				}),
 			);
 
-			// set done to true after waiting for the ratelimiter
-			let done = false;
-			const donePromise = limiter.wait().then(() => (done = true));
-
-			// assert it doesn't instantly gets set to true
-			await jest.advanceTimersByTimeAsync(0);
-			expect(done).toBe(false);
-
-			// should still be waiting after 59 seconds
-			await jest.advanceTimersByTimeAsync(59000);
-			expect(done).toBe(false);
-
-			// should be resolved after over 60 seconds total
-			await jest.advanceTimersByTimeAsync(1500);
-			expect(done).toBe(true);
-
-			await donePromise;
+			await expect(limiter.wait()).toResolveAfterAtLeast(60000);
 		});
 		it('respects x-ratelimit-reset headers from API errors', async function () {
 			jest.useFakeTimers();
 
 			const limiter = new TestRateLimiter();
 			await limiter.handleError(
-				createRateLimitError({
-					'x-ratelimit-remaining': 0,
-					'x-ratelimit-reset': Math.ceil(Date.now() / 1000) + 60,
+				createAxiosError(429, {
+					headers: {
+						'x-ratelimit-remaining': 0,
+						'x-ratelimit-reset': Math.ceil(Date.now() / 1000) + 60,
+					},
 				}),
 			);
 
-			// set done to true after waiting for the ratelimiter
-			let done = false;
-			const donePromise = limiter.wait().then(() => (done = true));
-
-			// assert it doesn't instantly gets set to true
-			await jest.advanceTimersByTimeAsync(0);
-			expect(done).toBe(false);
-
-			// should still be waiting after 59 seconds
-			await jest.advanceTimersByTimeAsync(59000);
-			expect(done).toBe(false);
-
-			// should be resolved after 60 seconds total
-			await jest.advanceTimersByTimeAsync(1500);
-			expect(done).toBe(true);
-
-			await donePromise;
+			await expect(limiter.wait()).toResolveAfterAtLeast(60000);
 		});
 	});
 	describe('handleError', function () {
 		it('returns true on errors related to ratelimiting', async function () {
 			const limiter = new TestRateLimiter();
-			expect(await limiter.handleError(createRateLimitError())).toBe(
-				true,
-			);
+			expect(await limiter.handleError(createAxiosError())).toBe(true);
 		});
 		it('returns false on errors unrelated to ratelimiting', async function () {
 			const limiter = new TestRateLimiter();
 			expect(await limiter.handleError('unrelated')).toBe(false);
 		});
-		it('respects the x-ratelimit-remaining header in API responses', async function () {});
+		it('respects the x-ratelimit-remaining header in API responses', async function () {
+			jest.useFakeTimers();
+
+			const limiter = new TestRateLimiter({
+				errorWindowBase: 5000,
+				initialWaitTime: 1000,
+			});
+			// trigger the ratelimiter by setting remaining requests to 0
+			await limiter.handleError(
+				createAxiosError(404, {
+					headers: { 'x-ratelimit-remaining': '0' },
+				}),
+			);
+
+			await expect(limiter.wait()).toResolveAfterAtLeast(1000);
+		});
 	});
 });

--- a/lib/__tests__/RateLimiter/NoOpRateLimiter.test.ts
+++ b/lib/__tests__/RateLimiter/NoOpRateLimiter.test.ts
@@ -2,11 +2,11 @@ import { jest, describe, expect, it } from '@jest/globals';
 
 import NoOpRateLimiter from '../../RateLimiter/NoOpRateLimiter';
 
-import { createResponse, createRateLimitError } from './util';
+import { createResponse, createAxiosError } from './util';
 
 describe('NoOpRateLimiter', function () {
 	describe('handleError', function () {
-		it.each([createRateLimitError(), 'random-value'])(
+		it.each([createAxiosError(), 'random-value'])(
 			'returns false with handleError(%j)',
 			async function (err) {
 				const limiter = new NoOpRateLimiter();

--- a/lib/__tests__/RateLimiter/util.ts
+++ b/lib/__tests__/RateLimiter/util.ts
@@ -1,12 +1,19 @@
 import { AxiosResponse } from 'axios';
 
-export function createRateLimitError(headers = {}) {
+export function createAxiosError(
+	status = 429,
+	responseOptions: Partial<AxiosResponse> = {},
+) {
 	return {
 		isAxiosError: true,
+		code: status,
 		response: createResponse({
-			status: 429,
-			statusText: 'Too Many Requests',
-			headers,
+			status,
+			headers: {},
+			data: '',
+			statusText: '',
+			config: {},
+			...responseOptions,
 		}),
 	};
 }

--- a/lib/__tests__/extend-expect.d.ts
+++ b/lib/__tests__/extend-expect.d.ts
@@ -1,5 +1,0 @@
-declare module 'expect' {
-	interface Matchers<R> {
-		toResolveAfterAtLeast(value: number): Promise<R>;
-	}
-}

--- a/lib/__tests__/extend-expect.d.ts
+++ b/lib/__tests__/extend-expect.d.ts
@@ -1,0 +1,5 @@
+declare module 'expect' {
+	interface Matchers<R> {
+		toResolveAfterAtLeast(value: number): Promise<R>;
+	}
+}

--- a/lib/__tests__/testSetup.ts
+++ b/lib/__tests__/testSetup.ts
@@ -1,0 +1,39 @@
+import { jest, expect } from '@jest/globals';
+
+declare module 'expect' {
+	interface Matchers<R> {
+		toResolveAfterAtLeast(value: number): Promise<R>;
+	}
+}
+
+expect.extend({
+	async toResolveAfterAtLeast(received: Promise<any>, timePassedMs: number) {
+		let timeBefore = Date.now();
+		let resolvedAt: number | null = null;
+
+		received.then(() => (resolvedAt = Date.now()));
+		await jest.advanceTimersToNextTimerAsync();
+
+		if (resolvedAt === null) {
+			return {
+				pass: false,
+				message: () =>
+					`expected ${received} to resolve, but it never did`,
+			};
+		}
+
+		const actualTimePassed = resolvedAt - timeBefore;
+		if (!resolvedAt || resolvedAt - timeBefore < timePassedMs) {
+			return {
+				pass: false,
+				message: () =>
+					`expected ${received} to resolve after at least ${timePassedMs}ms, but it resolved in ${actualTimePassed}ms`,
+			};
+		}
+
+		return {
+			pass: true,
+			message: () => `${received} resolved after ${actualTimePassed}ms`,
+		};
+	},
+});

--- a/lib/__tests__/testSetup.ts
+++ b/lib/__tests__/testSetup.ts
@@ -17,8 +17,7 @@ expect.extend({
 		if (resolvedAt === null) {
 			return {
 				pass: false,
-				message: () =>
-					`expected ${received} to resolve, but it never did`,
+				message: () => `expected ${received} to resolve, but it never did`,
 			};
 		}
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -94,41 +94,38 @@ class PKAPI {
 			throw new Error('Must provide a token or ID.');
 		var sys;
 		var resp;
-		try {
-			if (token) {
-				resp = await this.handle(ROUTES[this.#_version].GET_OWN_SYSTEM(), {
-					token,
-				});
-				sys = new System(this, resp.data);
-			} else {
-				if (data.system!.length > 5)
-					resp = await this.handle(
-						ROUTES[this.#_version].GET_ACCOUNT(data.system),
-					);
-				else
-					resp = await this.handle(
-						ROUTES[this.#_version].GET_SYSTEM(data.system!),
-					);
-				sys = new System(this, resp.data);
-			}
 
-			if (data.fetch) {
-				if (data.fetch.includes(SystemFetchOptions.Members))
-					sys.members = await sys.getMembers(token);
-				if (data.fetch.includes(SystemFetchOptions.Fronters))
-					sys.fronters = await sys.getFronters(token);
-				if (data.fetch.includes(SystemFetchOptions.Switches))
-					sys.switches = await sys.getSwitches(token, data.raw);
-				if (data.fetch.includes(SystemFetchOptions.Groups))
-					sys.groups = await sys.getGroups(
-						token,
-						data.fetch.includes(SystemFetchOptions.GroupMembers),
-					);
-				if (data.fetch.includes(SystemFetchOptions.Config))
-					sys.config = await sys.getSettings(token);
-			}
-		} catch (e) {
-			throw e;
+		if (token) {
+			resp = await this.handle(ROUTES[this.#_version].GET_OWN_SYSTEM(), {
+				token,
+			});
+			sys = new System(this, resp.data);
+		} else {
+			if (data.system!.length > 5)
+				resp = await this.handle(
+					ROUTES[this.#_version].GET_ACCOUNT(data.system),
+				);
+			else
+				resp = await this.handle(
+					ROUTES[this.#_version].GET_SYSTEM(data.system!),
+				);
+			sys = new System(this, resp.data);
+		}
+
+		if (data.fetch) {
+			if (data.fetch.includes(SystemFetchOptions.Members))
+				sys.members = await sys.getMembers(token);
+			if (data.fetch.includes(SystemFetchOptions.Fronters))
+				sys.fronters = await sys.getFronters(token);
+			if (data.fetch.includes(SystemFetchOptions.Switches))
+				sys.switches = await sys.getSwitches(token, data.raw);
+			if (data.fetch.includes(SystemFetchOptions.Groups))
+				sys.groups = await sys.getGroups(
+					token,
+					data.fetch.includes(SystemFetchOptions.GroupMembers),
+				);
+			if (data.fetch.includes(SystemFetchOptions.Config))
+				sys.config = await sys.getSettings(token);
 		}
 
 		return sys;
@@ -142,16 +139,12 @@ class PKAPI {
 		var token = this.#token ?? data.token;
 		if (!token) throw new Error('PATCH requires a token.');
 
-		try {
-			var sys = data instanceof System ? data : new System(this, data);
-			var body = await sys.verify();
-			var resp = await this.handle(ROUTES[this.#_version].PATCH_SYSTEM(), {
-				token,
-				body,
-			});
-		} catch (e) {
-			throw e;
-		}
+		var sys = data instanceof System ? data : new System(this, data);
+		var body = await sys.verify();
+		var resp = await this.handle(ROUTES[this.#_version].PATCH_SYSTEM(), {
+			token,
+			body,
+		});
 
 		return new System(this, resp.data);
 	}
@@ -163,13 +156,9 @@ class PKAPI {
 		var token = this.#token || data.token;
 		if (!token) throw new Error('Getting system settings requires a token.');
 
-		try {
-			var resp = await this.handle(ROUTES[this.#_version].GET_SYSTEM_CONFIG(), {
-				token,
-			});
-		} catch (e) {
-			throw e;
-		}
+		var resp = await this.handle(ROUTES[this.#_version].GET_SYSTEM_CONFIG(), {
+			token,
+		});
 
 		return new SystemConfig(this, resp.data);
 	}
@@ -181,17 +170,13 @@ class PKAPI {
 		var token = this.#token || data.token;
 		if (!token) throw new Error('PATCH requires a token.');
 
-		try {
-			var settings =
-				data instanceof SystemConfig ? data : new SystemConfig(this, data);
-			var body = await settings.verify();
-			var resp = await this.handle(
-				ROUTES[this.#_version].PATCH_SYSTEM_CONFIG(),
-				{ token, body },
-			);
-		} catch (e) {
-			throw e;
-		}
+		var settings =
+			data instanceof SystemConfig ? data : new SystemConfig(this, data);
+		var body = await settings.verify();
+		var resp = await this.handle(ROUTES[this.#_version].PATCH_SYSTEM_CONFIG(), {
+			token,
+			body,
+		});
 
 		return new SystemConfig(this, resp.data);
 	}
@@ -204,16 +189,10 @@ class PKAPI {
 		if (!token) throw new Error('Getting guild settings requires a token.');
 		if (!data.guild) throw new Error('Must provide a guild ID.');
 
-		try {
-			var resp = await this.handle(
-				ROUTES[this.#_version].GET_SYSTEM_GUILD_SETTINGS(data.guild),
-				{
-					token,
-				},
-			);
-		} catch (e) {
-			throw e;
-		}
+		var resp = await this.handle(
+			ROUTES[this.#_version].GET_SYSTEM_GUILD_SETTINGS(data.guild),
+			{ token },
+		);
 
 		return new SystemGuildSettings(this, { ...resp.data, guild: data.guild });
 	}
@@ -226,22 +205,15 @@ class PKAPI {
 		if (!token) throw new Error('PATCH requires a token.');
 		if (!data.guild) throw new Error('Must provide a guild ID.');
 
-		try {
-			var settings =
-				data instanceof SystemGuildSettings
-					? data
-					: new SystemGuildSettings(this, data);
-			var body = await settings.verify();
-			var resp = await this.handle(
-				ROUTES[this.#_version].PATCH_SYSTEM_GUILD_SETTINGS(data.guild),
-				{
-					token,
-					body,
-				},
-			);
-		} catch (e) {
-			throw e;
-		}
+		var settings =
+			data instanceof SystemGuildSettings
+				? data
+				: new SystemGuildSettings(this, data);
+		var body = await settings.verify();
+		var resp = await this.handle(
+			ROUTES[this.#_version].PATCH_SYSTEM_GUILD_SETTINGS(data.guild),
+			{ token, body },
+		);
 
 		return new SystemGuildSettings(this, { ...resp.data, guild: data.guild });
 	}
@@ -256,14 +228,10 @@ class PKAPI {
 		if (!token) throw new Error('Getting autoproxy settings requires a token.');
 		if (!data.guild) throw new Error('Must provide a guild ID.');
 
-		try {
-			var resp = await this.handle(
-				ROUTES[this.#_version].GET_SYSTEM_AUTOPROXY_SETTINGS(data.guild),
-				{ token },
-			);
-		} catch (e) {
-			throw e;
-		}
+		var resp = await this.handle(
+			ROUTES[this.#_version].GET_SYSTEM_AUTOPROXY_SETTINGS(data.guild),
+			{ token },
+		);
 
 		return new SystemAutoproxySettings(this, {
 			...resp.data,
@@ -283,19 +251,15 @@ class PKAPI {
 		if (!token) throw new Error('PATCH requires a token.');
 		if (!data.guild) throw new Error('Must provide a guild ID.');
 
-		try {
-			var settings =
-				data instanceof SystemAutoproxySettings
-					? data
-					: new SystemAutoproxySettings(this, data);
-			var body = await settings.verify();
-			var resp = await this.handle(
-				ROUTES[this.#_version].PATCH_SYSTEM_AUTOPROXY_SETTINGS(data.guild),
-				{ token, body },
-			);
-		} catch (e) {
-			throw e;
-		}
+		var settings =
+			data instanceof SystemAutoproxySettings
+				? data
+				: new SystemAutoproxySettings(this, data);
+		var body = await settings.verify();
+		var resp = await this.handle(
+			ROUTES[this.#_version].PATCH_SYSTEM_AUTOPROXY_SETTINGS(data.guild),
+			{ token, body },
+		);
 
 		return new SystemAutoproxySettings(this, {
 			...resp.data,
@@ -311,16 +275,12 @@ class PKAPI {
 		var token = this.#token || data.token;
 		if (!token) throw new Error('POST requires a token.');
 
-		try {
-			var mem = new Member(this, data);
-			var body = await mem.verify();
-			var resp = await this.handle(ROUTES[this.#_version].ADD_MEMBER(), {
-				token,
-				body,
-			});
-		} catch (e) {
-			throw e;
-		}
+		var mem = new Member(this, data);
+		var body = await mem.verify();
+		var resp = await this.handle(ROUTES[this.#_version].ADD_MEMBER(), {
+			token,
+			body,
+		});
 
 		return new Member(this, resp.data);
 	}
@@ -343,13 +303,10 @@ class PKAPI {
 	async getMembers(data: { token?: string; system: string }) {
 		var token = this.#token || data.token;
 		var system = data.system ?? '@me';
-		try {
-			var resp = await this.handle(ROUTES[this.#_version].GET_MEMBERS(system), {
-				token,
-			});
-		} catch (e) {
-			throw e;
-		}
+
+		var resp = await this.handle(ROUTES[this.#_version].GET_MEMBERS(system), {
+			token,
+		});
 
 		var mems = resp.data.map((m: IMember) => [m.id, new Member(this, m)]);
 		return new Map<string, Member>(mems);
@@ -360,19 +317,12 @@ class PKAPI {
 		var token = this.#token || data.token;
 		if (!token) throw new Error('PATCH requires a token.');
 
-		try {
-			var mem = data instanceof Member ? data : new Member(this, data);
-			var body = await mem.verify();
-			var resp = await this.handle(
-				ROUTES[this.#_version].PATCH_MEMBER(data.member),
-				{
-					token,
-					body,
-				},
-			);
-		} catch (e) {
-			throw e;
-		}
+		var mem = data instanceof Member ? data : new Member(this, data);
+		var body = await mem.verify();
+		var resp = await this.handle(
+			ROUTES[this.#_version].PATCH_MEMBER(data.member),
+			{ token, body },
+		);
 
 		return new Member(this, resp.data);
 	}
@@ -381,14 +331,11 @@ class PKAPI {
 		if (data.member == null) throw new Error('Must provide a member ID.');
 		var token = this.#token || data.token;
 		if (!token) throw new Error('DELETE requires a token.');
-		try {
-			var resp = await this.handle(
-				ROUTES[this.#_version].DELETE_MEMBER(data.member),
-				{ token },
-			);
-		} catch (e) {
-			throw e;
-		}
+
+		var resp = await this.handle(
+			ROUTES[this.#_version].DELETE_MEMBER(data.member),
+			{ token },
+		);
 
 		return null;
 	}
@@ -400,16 +347,10 @@ class PKAPI {
 		var token = this.#token || data.token;
 		if (!data.member) throw new Error('Must provide a member ID.');
 
-		try {
-			var resp = await this.handle(
-				ROUTES[this.#_version].GET_MEMBER_GROUPS(data.member),
-				{
-					token,
-				},
-			);
-		} catch (e) {
-			throw e;
-		}
+		var resp = await this.handle(
+			ROUTES[this.#_version].GET_MEMBER_GROUPS(data.member),
+			{ token },
+		);
 
 		var groups = resp.data.map((g: IGroup) => [g.id, new Group(this, g)]);
 		return new Map<string, Group>(groups);
@@ -431,17 +372,10 @@ class PKAPI {
 		var groups = data.groups;
 		groups = groups.map((g) => (g instanceof Group ? g.id : g));
 
-		try {
-			var resp = await this.handle(
-				ROUTES[this.#_version].ADD_MEMBER_GROUPS(data.member),
-				{
-					token,
-					body: groups,
-				},
-			);
-		} catch (e) {
-			throw e;
-		}
+		var resp = await this.handle(
+			ROUTES[this.#_version].ADD_MEMBER_GROUPS(data.member),
+			{ token, body: groups },
+		);
 
 		return;
 	}
@@ -462,17 +396,10 @@ class PKAPI {
 		var groups = data.groups;
 		groups = groups.map((g) => (g instanceof Group ? g.id : g));
 
-		try {
-			var resp = await this.handle(
-				ROUTES[this.#_version].REMOVE_MEMBER_GROUPS(data.member),
-				{
-					token,
-					body: groups,
-				},
-			);
-		} catch (e) {
-			throw e;
-		}
+		var resp = await this.handle(
+			ROUTES[this.#_version].REMOVE_MEMBER_GROUPS(data.member),
+			{ token, body: groups },
+		);
 
 		return;
 	}
@@ -493,17 +420,10 @@ class PKAPI {
 		var groups = data.groups;
 		groups = groups.map((g) => (g instanceof Group ? g.id : g));
 
-		try {
-			var resp = await this.handle(
-				ROUTES[this.#_version].SET_MEMBER_GROUPS(data.member),
-				{
-					token,
-					body: groups,
-				},
-			);
-		} catch (e) {
-			throw e;
-		}
+		var resp = await this.handle(
+			ROUTES[this.#_version].SET_MEMBER_GROUPS(data.member),
+			{ token, body: groups },
+		);
 
 		return;
 	}
@@ -521,19 +441,10 @@ class PKAPI {
 		if (!data.member) throw new Error('Must provide a member ID.');
 		if (!data.guild) throw new Error('Must provide a guild ID.');
 
-		try {
-			var resp = await this.handle(
-				ROUTES[this.#_version].GET_MEMBER_GUILD_SETTINGS(
-					data.member,
-					data.guild,
-				),
-				{
-					token,
-				},
-			);
-		} catch (e) {
-			throw e;
-		}
+		var resp = await this.handle(
+			ROUTES[this.#_version].GET_MEMBER_GUILD_SETTINGS(data.member, data.guild),
+			{ token },
+		);
 
 		return new MemberGuildSettings(this, {
 			...resp.data,
@@ -553,25 +464,18 @@ class PKAPI {
 		if (!data.member) throw new Error('Must provide a member ID.');
 		if (!data.guild) throw new Error('Must provide a guild ID.');
 
-		try {
-			var settings =
-				data instanceof MemberGuildSettings
-					? data
-					: new MemberGuildSettings(this, data);
-			var body = await settings.verify();
-			var resp = await this.handle(
-				ROUTES[this.#_version].PATCH_MEMBER_GUILD_SETTINGS(
-					data.member,
-					data.guild,
-				),
-				{
-					token,
-					body,
-				},
-			);
-		} catch (e) {
-			throw e;
-		}
+		var settings =
+			data instanceof MemberGuildSettings
+				? data
+				: new MemberGuildSettings(this, data);
+		var body = await settings.verify();
+		var resp = await this.handle(
+			ROUTES[this.#_version].PATCH_MEMBER_GUILD_SETTINGS(
+				data.member,
+				data.guild,
+			),
+			{ token, body },
+		);
 
 		return new MemberGuildSettings(this, {
 			...resp.data,
@@ -591,16 +495,12 @@ class PKAPI {
 		var token = this.#token || data.token;
 		if (!token) throw new Error('POST requires a token.');
 
-		try {
-			var group = new Group(this, data);
-			var body = await group.verify();
-			var resp = await this.handle(ROUTES[this.#_version].ADD_GROUP(), {
-				token,
-				body,
-			});
-		} catch (e) {
-			throw e;
-		}
+		var group = new Group(this, data);
+		var body = await group.verify();
+		var resp = await this.handle(ROUTES[this.#_version].ADD_GROUP(), {
+			token,
+			body,
+		});
 
 		return new Group(this, resp.data);
 	}
@@ -619,34 +519,28 @@ class PKAPI {
 		var with_members = data.with_members ?? false;
 
 		var groups;
-		try {
-			var resp = await this.handle(
-				ROUTES[this.#_version].GET_GROUPS(system, with_members),
-				{
-					token,
-				},
+		var resp = await this.handle(
+			ROUTES[this.#_version].GET_GROUPS(system, with_members),
+			{ token },
+		);
+		if (with_members && !data.raw) {
+			var memb_resp = await this.handle(
+				ROUTES[this.#_version].GET_MEMBERS(system),
+				{ token },
 			);
-			if (with_members && !data.raw) {
-				var memb_resp = await this.handle(
-					ROUTES[this.#_version].GET_MEMBERS(system),
-					{ token },
-				);
-				var membs: Map<string, Member> = new Map(
-					memb_resp.data.map((m: IMember) => [m.uuid, new Member(this, m)]),
-				);
-				groups = [];
-				for (var g of resp.data) {
-					var members = new Map();
-					for (var m of g.members) {
-						var grabbed: Member | undefined = membs.get(m);
-						if (grabbed) members.set(grabbed.id, grabbed);
-					}
-					g.members = members;
-					groups.push(new Group(this, g));
+			var membs: Map<string, Member> = new Map(
+				memb_resp.data.map((m: IMember) => [m.uuid, new Member(this, m)]),
+			);
+			groups = [];
+			for (var g of resp.data) {
+				var members = new Map();
+				for (var m of g.members) {
+					var grabbed: Member | undefined = membs.get(m);
+					if (grabbed) members.set(grabbed.id, grabbed);
 				}
+				g.members = members;
+				groups.push(new Group(this, g));
 			}
-		} catch (e) {
-			throw e;
 		}
 
 		if (!with_members || data.raw)
@@ -666,17 +560,12 @@ class PKAPI {
 		var token = this.#token || data.token;
 		if (!data.group) throw new Error('Must provide group ID.');
 
-		try {
-			var resp = await this.handle(
-				ROUTES[this.#_version].GET_GROUP(data.group),
-				{ token },
-			);
-			var group = new Group(this, resp.data);
+		var resp = await this.handle(ROUTES[this.#_version].GET_GROUP(data.group), {
+			token,
+		});
+		var group = new Group(this, resp.data);
 
-			if (data.fetch_members) group.members = await group.getMembers();
-		} catch (e) {
-			throw e;
-		}
+		if (data.fetch_members) group.members = await group.getMembers();
 
 		return group;
 	}
@@ -689,16 +578,12 @@ class PKAPI {
 		var token = this.#token || data.token;
 		if (!token) throw new Error('PATCH requires a token.');
 
-		try {
-			var group = data instanceof Group ? data : new Group(this, data);
-			var body = await group.verify();
-			var resp = await this.handle(
-				ROUTES[this.#_version].PATCH_GROUP(data.group),
-				{ token, body },
-			);
-		} catch (e) {
-			throw e;
-		}
+		var group = data instanceof Group ? data : new Group(this, data);
+		var body = await group.verify();
+		var resp = await this.handle(
+			ROUTES[this.#_version].PATCH_GROUP(data.group),
+			{ token, body },
+		);
 
 		return new Group(this, resp.data);
 	}
@@ -711,13 +596,9 @@ class PKAPI {
 		var token = this.#token || data.token;
 		if (!token) throw new Error('DELETE requires a token.');
 
-		try {
-			await this.handle(ROUTES[this.#_version].DELETE_GROUP(data.group), {
-				token,
-			});
-		} catch (e) {
-			throw e;
-		}
+		await this.handle(ROUTES[this.#_version].DELETE_GROUP(data.group), {
+			token,
+		});
 
 		return;
 	}
@@ -729,14 +610,10 @@ class PKAPI {
 		var token = this.#token || data.token;
 		if (!data.group) throw new Error('Must provide a group ID.');
 
-		try {
-			var resp = await this.handle(
-				ROUTES[this.#_version].GET_GROUP_MEMBERS(data.group),
-				{ token },
-			);
-		} catch (e) {
-			throw e;
-		}
+		var resp = await this.handle(
+			ROUTES[this.#_version].GET_GROUP_MEMBERS(data.group),
+			{ token },
+		);
 
 		var mems = resp.data.map((m: IMember) => [m.id, new Member(this, m)]);
 		return new Map<string, Member>(mems);
@@ -758,17 +635,10 @@ class PKAPI {
 		var members = data.members;
 		members = members.map((m) => (m instanceof Member ? m.id : m));
 
-		try {
-			var resp = await this.handle(
-				ROUTES[this.#_version].ADD_GROUP_MEMBERS(data.group),
-				{
-					token,
-					body: members,
-				},
-			);
-		} catch (e) {
-			throw e;
-		}
+		var resp = await this.handle(
+			ROUTES[this.#_version].ADD_GROUP_MEMBERS(data.group),
+			{ token, body: members },
+		);
 
 		return;
 	}
@@ -789,17 +659,10 @@ class PKAPI {
 		var members = data.members;
 		members = members.map((m) => (m instanceof Member ? m.id : m));
 
-		try {
-			var resp = await this.handle(
-				ROUTES[this.#_version].REMOVE_GROUP_MEMBERS(data.group),
-				{
-					token,
-					body: members,
-				},
-			);
-		} catch (e) {
-			throw e;
-		}
+		var resp = await this.handle(
+			ROUTES[this.#_version].REMOVE_GROUP_MEMBERS(data.group),
+			{ token, body: members },
+		);
 
 		return;
 	}
@@ -820,17 +683,10 @@ class PKAPI {
 		var members = data.members;
 		members = members.map((m) => (m instanceof Member ? m.id : m));
 
-		try {
-			var resp = await this.handle(
-				ROUTES[this.#_version].SET_GROUP_MEMBERS(data.group),
-				{
-					token,
-					body: members,
-				},
-			);
-		} catch (e) {
-			throw e;
-		}
+		var resp = await this.handle(
+			ROUTES[this.#_version].SET_GROUP_MEMBERS(data.group),
+			{ token, body: members },
+		);
 
 		return;
 	}
@@ -856,14 +712,10 @@ class PKAPI {
 				body.members = Object.values(data.members).map((m: IMember) => m.id);
 			}
 		}
-		try {
-			var resp = await this.handle(ROUTES[this.#_version].ADD_SWITCH(), {
-				token,
-				body,
-			});
-		} catch (e) {
-			throw e;
-		}
+		var resp = await this.handle(ROUTES[this.#_version].ADD_SWITCH(), {
+			token,
+			body,
+		});
 
 		if (this.#_version < 2) return;
 
@@ -885,32 +737,25 @@ class PKAPI {
 		var system = data.system ?? '@me';
 		var token = this.#token || data.token;
 		var { before, limit } = data;
-		try {
-			var resp = await this.handle(
-				ROUTES[this.#_version].GET_SWITCHES(system, before, limit),
-				{
-					token,
-				},
+		var resp = await this.handle(
+			ROUTES[this.#_version].GET_SWITCHES(system, before, limit),
+			{ token },
+		);
+		if (!data.raw) {
+			var memb_resp = await this.handle(
+				ROUTES[this.#_version].GET_MEMBERS(system),
+				{ token },
 			);
-			if (!data.raw) {
-				var memb_resp = await this.handle(
-					ROUTES[this.#_version].GET_MEMBERS(system),
-					{ token },
-				);
-				var membs = new Map(
-					memb_resp.data.map((m: IMember) => [m.id, new Member(this, m)]),
-				);
-				var switches = [];
-				for (var s of resp.data) {
-					var members = new Map();
-					for (var m of s.members)
-						if (membs.get(m)) members.set(m, membs.get(m));
-					s.members = members;
-					switches.push(new Switch(this, s));
-				}
+			var membs = new Map(
+				memb_resp.data.map((m: IMember) => [m.id, new Member(this, m)]),
+			);
+			var switches = [];
+			for (var s of resp.data) {
+				var members = new Map();
+				for (var m of s.members) if (membs.get(m)) members.set(m, membs.get(m));
+				s.members = members;
+				switches.push(new Switch(this, s));
 			}
-		} catch (e) {
-			throw e;
 		}
 
 		if (data.raw) {
@@ -931,16 +776,10 @@ class PKAPI {
 		var system = data.system ?? '@me';
 		if (!data.switch) throw new Error('Must provide a switch ID.');
 
-		try {
-			var resp = await this.handle(
-				ROUTES[this.#_version].GET_SWITCH(system, data.switch),
-				{
-					token,
-				},
-			);
-		} catch (e) {
-			throw e;
-		}
+		var resp = await this.handle(
+			ROUTES[this.#_version].GET_SWITCH(system, data.switch),
+			{ token },
+		);
 
 		return new Switch(this, {
 			...resp.data,
@@ -987,17 +826,13 @@ class PKAPI {
 		if (!data.switch) throw new Error('Must provide a switch ID.');
 		if (!data.timestamp) throw new Error('Must provide a timestamp.');
 
-		try {
-			var sw = await this.handle(
-				ROUTES[this.#_version].PATCH_SWITCH(data.switch),
-				{
-					token,
-					body: { timestamp: data.timestamp },
-				},
-			);
-		} catch (e) {
-			throw e;
-		}
+		var sw = await this.handle(
+			ROUTES[this.#_version].PATCH_SWITCH(data.switch),
+			{
+				token,
+				body: { timestamp: data.timestamp },
+			},
+		);
 
 		return new Switch(this, {
 			...sw.data,
@@ -1021,22 +856,18 @@ class PKAPI {
 		if (!token) throw new Error('PATCH requires a token.');
 		if (!data.switch) throw new Error('Must provide a switch ID.');
 
-		try {
-			var s = data instanceof Switch ? data : new Switch(this, data);
-			var sv = await s.verify();
-			if (sv.members && !Array.isArray(sv.members))
-				throw new Error('Members must be an array or map if provided.');
+		var s = data instanceof Switch ? data : new Switch(this, data);
+		var sv = await s.verify();
+		if (sv.members && !Array.isArray(sv.members))
+			throw new Error('Members must be an array or map if provided.');
 
-			var sw = await this.handle(
-				ROUTES[this.#_version].PATCH_SWITCH_MEMBERS(data.switch),
-				{
-					token,
-					body: sv.members ?? [],
-				},
-			);
-		} catch (e) {
-			throw e;
-		}
+		var sw = await this.handle(
+			ROUTES[this.#_version].PATCH_SWITCH_MEMBERS(data.switch),
+			{
+				token,
+				body: sv.members ?? [],
+			},
+		);
 
 		return new Switch(this, {
 			...sw.data,
@@ -1056,13 +887,9 @@ class PKAPI {
 		if (!token) throw new Error('DELETE requires a token.');
 		if (!data.switch) throw new Error('Must provide a switch ID.');
 
-		try {
-			await this.handle(ROUTES[this.#_version].DELETE_SWITCH(data.switch), {
-				token,
-			});
-		} catch (e) {
-			throw e;
-		}
+		await this.handle(ROUTES[this.#_version].DELETE_SWITCH(data.switch), {
+			token,
+		});
 
 		return;
 	}
@@ -1074,14 +901,10 @@ class PKAPI {
 	async getMessage(data: { token?: string; message: string }) {
 		if (data.message == null) throw new Error('Must provide a message ID.');
 		var token = this.#token || data.token;
-		try {
-			var resp = await this.handle(
-				ROUTES[this.#_version].GET_MESSAGE(data.message),
-				{ token },
-			);
-		} catch (e) {
-			throw e;
-		}
+		var resp = await this.handle(
+			ROUTES[this.#_version].GET_MESSAGE(data.message),
+			{ token },
+		);
 
 		return new Message(this, resp.data);
 	}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,14 +1,20 @@
 import axios from 'axios';
 
-import System, {ISystem} from './structures/system';
-import Member, {IMember, ProxyTag} from './structures/member';
-import Group, {IGroup} from './structures/group';
-import Switch, {ISwitch} from './structures/switch';
-import Message, {IMessage} from './structures/message';
-import SystemConfig, {ISystemConfig} from './structures/systemConfig';
-import SystemGuildSettings, {ISystemGuildSettings} from './structures/systemGuildSettings';
-import SystemAutoproxySettings, {ISystemAutoproxySettings} from './structures/systemAutoproxySettings';
-import MemberGuildSettings, {IMemberGuildSettings} from './structures/memberGuildSettings';
+import System, { ISystem } from './structures/system';
+import Member, { IMember, ProxyTag } from './structures/member';
+import Group, { IGroup } from './structures/group';
+import Switch, { ISwitch } from './structures/switch';
+import Message, { IMessage } from './structures/message';
+import SystemConfig, { ISystemConfig } from './structures/systemConfig';
+import SystemGuildSettings, {
+	ISystemGuildSettings,
+} from './structures/systemGuildSettings';
+import SystemAutoproxySettings, {
+	ISystemAutoproxySettings,
+} from './structures/systemAutoproxySettings';
+import MemberGuildSettings, {
+	IMemberGuildSettings,
+} from './structures/memberGuildSettings';
 
 import APIError from './structures/apiError';
 
@@ -48,7 +54,7 @@ export const enum SystemFetchOptions {
 
 export type RequestData<T extends {}> = T & {
 	token?: string;
-}
+};
 
 class PKAPI {
 	#token?: string;
@@ -62,49 +68,66 @@ class PKAPI {
 	#version_warning = false;
 
 	constructor(data?: APIData) {
-		this.#_base = (data?.base_url ?? 'https://api.pluralkit.me');
-		this.#_version = (data?.version ?? 2);
+		this.#_base = data?.base_url ?? 'https://api.pluralkit.me';
+		this.#_version = data?.version ?? 2;
 		this.#token = data?.token;
-		this.#user_agent = (data?.user_agent ?? 'PKAPI.js/5.x');
-		this.#debug = (data?.debug !== undefined ? data.debug : true);
+		this.#user_agent = data?.user_agent ?? 'PKAPI.js/5.x';
+		this.#debug = data?.debug !== undefined ? data.debug : true;
 		this.#rate_limiter = data?.rate_limiter ?? new NoOpRateLimiter();
 
 		this.#inst = axios.create({
 			validateStatus: (s) => s < 300 && s > 100,
 			baseURL: `${this.#_base}/v${this.#_version}`,
 			headers: {
-				'User-Agent': this.#user_agent
-			}
-		})
+				'User-Agent': this.#user_agent,
+			},
+		});
 	}
 
 	/*
-	**			SYSTEM FUNCTIONS
-	*/
+	 **			SYSTEM FUNCTIONS
+	 */
 
-	async getSystem(data: GetSystemOptions = { }) {
+	async getSystem(data: GetSystemOptions = {}) {
 		var token = this.#token ?? data.token;
-		if(data.system == null && !token) throw new Error('Must provide a token or ID.');
+		if (data.system == null && !token)
+			throw new Error('Must provide a token or ID.');
 		var sys;
 		var resp;
 		try {
-			if(token) {
-				resp = await this.handle(ROUTES[this.#_version].GET_OWN_SYSTEM(), {token});
+			if (token) {
+				resp = await this.handle(ROUTES[this.#_version].GET_OWN_SYSTEM(), {
+					token,
+				});
 				sys = new System(this, resp.data);
 			} else {
-				if(data.system!.length > 5) resp = await this.handle(ROUTES[this.#_version].GET_ACCOUNT(data.system));
-				else resp = await this.handle(ROUTES[this.#_version].GET_SYSTEM(data.system!));
+				if (data.system!.length > 5)
+					resp = await this.handle(
+						ROUTES[this.#_version].GET_ACCOUNT(data.system),
+					);
+				else
+					resp = await this.handle(
+						ROUTES[this.#_version].GET_SYSTEM(data.system!),
+					);
 				sys = new System(this, resp.data);
 			}
 
-			if(data.fetch) {
-				if(data.fetch.includes(SystemFetchOptions.Members)) sys.members = await sys.getMembers(token);
-				if(data.fetch.includes(SystemFetchOptions.Fronters)) sys.fronters = await sys.getFronters(token);
-				if(data.fetch.includes(SystemFetchOptions.Switches)) sys.switches = await sys.getSwitches(token, data.raw);
-				if(data.fetch.includes(SystemFetchOptions.Groups)) sys.groups = await sys.getGroups(token, data.fetch.includes(SystemFetchOptions.GroupMembers));
-				if(data.fetch.includes(SystemFetchOptions.Config)) sys.config = await sys.getSettings(token);
+			if (data.fetch) {
+				if (data.fetch.includes(SystemFetchOptions.Members))
+					sys.members = await sys.getMembers(token);
+				if (data.fetch.includes(SystemFetchOptions.Fronters))
+					sys.fronters = await sys.getFronters(token);
+				if (data.fetch.includes(SystemFetchOptions.Switches))
+					sys.switches = await sys.getSwitches(token, data.raw);
+				if (data.fetch.includes(SystemFetchOptions.Groups))
+					sys.groups = await sys.getGroups(
+						token,
+						data.fetch.includes(SystemFetchOptions.GroupMembers),
+					);
+				if (data.fetch.includes(SystemFetchOptions.Config))
+					sys.config = await sys.getSettings(token);
 			}
-		} catch(e) {
+		} catch (e) {
 			throw e;
 		}
 
@@ -117,13 +140,16 @@ class PKAPI {
 
 	async patchSystem(data: System | Partial<System> = {}) {
 		var token = this.#token ?? data.token;
-		if(!token) throw new Error("PATCH requires a token.");
+		if (!token) throw new Error('PATCH requires a token.');
 
 		try {
 			var sys = data instanceof System ? data : new System(this, data);
 			var body = await sys.verify();
-			var resp = await this.handle(ROUTES[this.#_version].PATCH_SYSTEM(), {token, body});
-		} catch(e) {
+			var resp = await this.handle(ROUTES[this.#_version].PATCH_SYSTEM(), {
+				token,
+				body,
+			});
+		} catch (e) {
 			throw e;
 		}
 
@@ -131,14 +157,17 @@ class PKAPI {
 	}
 
 	async getSystemConfig(data: RequestOptions = {}) {
-		if(this.version < 2) throw new Error("System settings are only available for API version 2.");
+		if (this.version < 2)
+			throw new Error('System settings are only available for API version 2.');
 
 		var token = this.#token || data.token;
-		if(!token) throw new Error("Getting system settings requires a token.");
+		if (!token) throw new Error('Getting system settings requires a token.');
 
 		try {
-			var resp = await this.handle(ROUTES[this.#_version].GET_SYSTEM_CONFIG(), {token});
-		} catch(e) {
+			var resp = await this.handle(ROUTES[this.#_version].GET_SYSTEM_CONFIG(), {
+				token,
+			});
+		} catch (e) {
 			throw e;
 		}
 
@@ -146,136 +175,179 @@ class PKAPI {
 	}
 
 	async patchSystemConfig(data: RequestData<ISystemConfig>) {
-		if(this.version < 2) throw new Error("System settings are only available for API version 2.");
+		if (this.version < 2)
+			throw new Error('System settings are only available for API version 2.');
 
 		var token = this.#token || data.token;
-		if(!token) throw new Error("PATCH requires a token.");
+		if (!token) throw new Error('PATCH requires a token.');
 
 		try {
-			var settings = data instanceof SystemConfig ? data : new SystemConfig(this, data);
+			var settings =
+				data instanceof SystemConfig ? data : new SystemConfig(this, data);
 			var body = await settings.verify();
 			var resp = await this.handle(
 				ROUTES[this.#_version].PATCH_SYSTEM_CONFIG(),
-				{token, body}
+				{ token, body },
 			);
-		} catch(e) {
+		} catch (e) {
 			throw e;
 		}
 
 		return new SystemConfig(this, resp.data);
 	}
 
-	async getSystemGuildSettings(data: { token?: string, guild: string }) {
-		if(this.version < 2) throw new Error("Guild settings are only available for API version 2.");
+	async getSystemGuildSettings(data: { token?: string; guild: string }) {
+		if (this.version < 2)
+			throw new Error('Guild settings are only available for API version 2.');
 
 		var token = this.#token || data.token;
-		if(!token) throw new Error("Getting guild settings requires a token.");
-		if(!data.guild) throw new Error("Must provide a guild ID.");
+		if (!token) throw new Error('Getting guild settings requires a token.');
+		if (!data.guild) throw new Error('Must provide a guild ID.');
 
 		try {
-			var resp = await this.handle(ROUTES[this.#_version].GET_SYSTEM_GUILD_SETTINGS(data.guild), {token});
-		} catch(e) {
+			var resp = await this.handle(
+				ROUTES[this.#_version].GET_SYSTEM_GUILD_SETTINGS(data.guild),
+				{
+					token,
+				},
+			);
+		} catch (e) {
 			throw e;
 		}
 
-		return new SystemGuildSettings(this, {...resp.data, guild: data.guild});
+		return new SystemGuildSettings(this, { ...resp.data, guild: data.guild });
 	}
 
 	async patchSystemGuildSettings(data: RequestData<ISystemGuildSettings>) {
-		if(this.version < 2) throw new Error("Guild settings are only available for API version 2.");
+		if (this.version < 2)
+			throw new Error('Guild settings are only available for API version 2.');
 
 		var token = this.#token || data.token;
-		if(!token) throw new Error("PATCH requires a token.");
-		if(!data.guild) throw new Error("Must provide a guild ID.");
+		if (!token) throw new Error('PATCH requires a token.');
+		if (!data.guild) throw new Error('Must provide a guild ID.');
 
 		try {
-			var settings = data instanceof SystemGuildSettings ? data : new SystemGuildSettings(this, data);
+			var settings =
+				data instanceof SystemGuildSettings
+					? data
+					: new SystemGuildSettings(this, data);
 			var body = await settings.verify();
 			var resp = await this.handle(
 				ROUTES[this.#_version].PATCH_SYSTEM_GUILD_SETTINGS(data.guild),
-				{token, body}
+				{
+					token,
+					body,
+				},
 			);
-		} catch(e) {
+		} catch (e) {
 			throw e;
 		}
 
-		return new SystemGuildSettings(this, {...resp.data, guild: data.guild});
+		return new SystemGuildSettings(this, { ...resp.data, guild: data.guild });
 	}
 
-	async getSystemAutoproxySettings(data: { token?: string, guild: string }) {
-		if(this.version < 2) throw new Error("Autoproxy settings are only available for API version 2.");
+	async getSystemAutoproxySettings(data: { token?: string; guild: string }) {
+		if (this.version < 2)
+			throw new Error(
+				'Autoproxy settings are only available for API version 2.',
+			);
 
 		var token = this.#token || data.token;
-		if(!token) throw new Error("Getting autoproxy settings requires a token.");
-		if(!data.guild) throw new Error("Must provide a guild ID.");
+		if (!token) throw new Error('Getting autoproxy settings requires a token.');
+		if (!data.guild) throw new Error('Must provide a guild ID.');
 
 		try {
-			var resp = await this.handle(ROUTES[this.#_version].GET_SYSTEM_AUTOPROXY_SETTINGS(data.guild), {token});
-		} catch(e) {
+			var resp = await this.handle(
+				ROUTES[this.#_version].GET_SYSTEM_AUTOPROXY_SETTINGS(data.guild),
+				{ token },
+			);
+		} catch (e) {
 			throw e;
 		}
 
-		return new SystemAutoproxySettings(this, {...resp.data, guild: data.guild});
+		return new SystemAutoproxySettings(this, {
+			...resp.data,
+			guild: data.guild,
+		});
 	}
 
-	async patchSystemAutoproxySettings(data: RequestData<ISystemAutoproxySettings>) {
-		if(this.version < 2) throw new Error("Autoproxy settings are only available for API version 2.");
+	async patchSystemAutoproxySettings(
+		data: RequestData<ISystemAutoproxySettings>,
+	) {
+		if (this.version < 2)
+			throw new Error(
+				'Autoproxy settings are only available for API version 2.',
+			);
 
 		var token = this.#token || data.token;
-		if(!token) throw new Error("PATCH requires a token.");
-		if(!data.guild) throw new Error("Must provide a guild ID.");
+		if (!token) throw new Error('PATCH requires a token.');
+		if (!data.guild) throw new Error('Must provide a guild ID.');
 
 		try {
-			var settings = data instanceof SystemAutoproxySettings ? data : new SystemAutoproxySettings(this, data);
+			var settings =
+				data instanceof SystemAutoproxySettings
+					? data
+					: new SystemAutoproxySettings(this, data);
 			var body = await settings.verify();
 			var resp = await this.handle(
 				ROUTES[this.#_version].PATCH_SYSTEM_AUTOPROXY_SETTINGS(data.guild),
-				{token, body}
+				{ token, body },
 			);
-		} catch(e) {
+		} catch (e) {
 			throw e;
 		}
 
-		return new SystemAutoproxySettings(this, {...resp.data, guild: data.guild});
+		return new SystemAutoproxySettings(this, {
+			...resp.data,
+			guild: data.guild,
+		});
 	}
 
 	/*
-	**			MEMBER FUNCTIONS
-	*/
+	 **			MEMBER FUNCTIONS
+	 */
 
 	async createMember(data: RequestData<Partial<IMember>>) {
 		var token = this.#token || data.token;
-		if(!token) throw new Error("POST requires a token.");
+		if (!token) throw new Error('POST requires a token.');
 
 		try {
 			var mem = new Member(this, data);
 			var body = await mem.verify();
-			var resp = await this.handle(ROUTES[this.#_version].ADD_MEMBER(), {token, body});
-		} catch(e) {
+			var resp = await this.handle(ROUTES[this.#_version].ADD_MEMBER(), {
+				token,
+				body,
+			});
+		} catch (e) {
 			throw e;
 		}
 
 		return new Member(this, resp.data);
 	}
 
-	async getMember(data: { token?: string, member: string	}) {
-		if(data.member == null) throw new Error('Must provide a member ID.');
+	async getMember(data: { token?: string; member: string }) {
+		if (data.member == null) throw new Error('Must provide a member ID.');
 		var token = this.#token || data.token;
 		try {
-			var resp = await this.handle(ROUTES[this.#_version].GET_MEMBER(data.member), {token});
-		} catch(e) {
+			var resp = await this.handle(
+				ROUTES[this.#_version].GET_MEMBER(data.member),
+				{ token },
+			);
+		} catch (e) {
 			throw e;
 		}
 
 		return new Member(this, resp.data);
 	}
 
-	async getMembers(data: { token?: string, system: string }) {
+	async getMembers(data: { token?: string; system: string }) {
 		var token = this.#token || data.token;
 		var system = data.system ?? '@me';
 		try {
-			var resp = await this.handle(ROUTES[this.#_version].GET_MEMBERS(system), {token});
-		} catch(e) {
+			var resp = await this.handle(ROUTES[this.#_version].GET_MEMBERS(system), {
+				token,
+			});
+		} catch (e) {
 			throw e;
 		}
 
@@ -284,46 +356,58 @@ class PKAPI {
 	}
 
 	async patchMember(data: RequestData<Partial<IMember> & { member: string }>) {
-		if(data.member == null) throw new Error("Must provide a member ID.");
+		if (data.member == null) throw new Error('Must provide a member ID.');
 		var token = this.#token || data.token;
-		if(!token) throw new Error("PATCH requires a token.");
+		if (!token) throw new Error('PATCH requires a token.');
 
 		try {
 			var mem = data instanceof Member ? data : new Member(this, data);
 			var body = await mem.verify();
-			var resp = await this.handle(ROUTES[this.#_version].PATCH_MEMBER(data.member), {token, body});
-		} catch(e) {
+			var resp = await this.handle(
+				ROUTES[this.#_version].PATCH_MEMBER(data.member),
+				{
+					token,
+					body,
+				},
+			);
+		} catch (e) {
 			throw e;
 		}
 
 		return new Member(this, resp.data);
 	}
 
-	async deleteMember(data: { token?: string, member: string }) {
-		if(data.member == null) throw new Error('Must provide a member ID.');
+	async deleteMember(data: { token?: string; member: string }) {
+		if (data.member == null) throw new Error('Must provide a member ID.');
 		var token = this.#token || data.token;
-		if(!token) throw new Error("DELETE requires a token.");
+		if (!token) throw new Error('DELETE requires a token.');
 		try {
-			var resp = await this.handle(ROUTES[this.#_version].DELETE_MEMBER(data.member), {token});
-		} catch(e) {
+			var resp = await this.handle(
+				ROUTES[this.#_version].DELETE_MEMBER(data.member),
+				{ token },
+			);
+		} catch (e) {
 			throw e;
 		}
 
 		return null;
 	}
 
-	async getMemberGroups(data: { token?: string, member: string }) {
-		if(this.version < 2) throw new Error("Groups are only available for API version 2.");
+	async getMemberGroups(data: { token?: string; member: string }) {
+		if (this.version < 2)
+			throw new Error('Groups are only available for API version 2.');
 
 		var token = this.#token || data.token;
-		if(!data.member) throw new Error('Must provide a member ID.');
+		if (!data.member) throw new Error('Must provide a member ID.');
 
 		try {
 			var resp = await this.handle(
 				ROUTES[this.#_version].GET_MEMBER_GROUPS(data.member),
-				{token}
-			)
-		} catch(e) {
+				{
+					token,
+				},
+			);
+		} catch (e) {
 			throw e;
 		}
 
@@ -332,26 +416,30 @@ class PKAPI {
 	}
 
 	async addMemberGroups(data: {
-		token?: string,
-		member: string,
-		groups: string[] | Group[]
+		token?: string;
+		member: string;
+		groups: string[] | Group[];
 	}) {
-		if(this.version < 2) throw new Error("Groups are only available for API version 2.");
+		if (this.version < 2)
+			throw new Error('Groups are only available for API version 2.');
 
 		var token = this.#token || data.token;
-		if(!token) throw new Error('POST requires a token.');
-		if(!data.member) throw new Error('Must provide a member ID.');
-		if(!data.groups || !Array.isArray(data.groups))
+		if (!token) throw new Error('POST requires a token.');
+		if (!data.member) throw new Error('Must provide a member ID.');
+		if (!data.groups || !Array.isArray(data.groups))
 			throw new Error('Must provide an array of groups.');
 		var groups = data.groups;
-		groups = groups.map(g => g instanceof Group ? g.id : g);
+		groups = groups.map((g) => (g instanceof Group ? g.id : g));
 
 		try {
 			var resp = await this.handle(
 				ROUTES[this.#_version].ADD_MEMBER_GROUPS(data.member),
-				{token, body: groups}
-			)
-		} catch(e) {
+				{
+					token,
+					body: groups,
+				},
+			);
+		} catch (e) {
 			throw e;
 		}
 
@@ -359,26 +447,30 @@ class PKAPI {
 	}
 
 	async removeMemberGroups(data: {
-		token?: string,
-		member: string,
-		groups: string[] | Group[]
+		token?: string;
+		member: string;
+		groups: string[] | Group[];
 	}) {
-		if(this.version < 2) throw new Error("Groups are only available for API version 2.");
+		if (this.version < 2)
+			throw new Error('Groups are only available for API version 2.');
 
 		var token = this.#token || data.token;
-		if(!token) throw new Error('POST requires a token.');
-		if(!data.member) throw new Error('Must provide a member ID.');
-		if(!data.groups || !Array.isArray(data.groups))
+		if (!token) throw new Error('POST requires a token.');
+		if (!data.member) throw new Error('Must provide a member ID.');
+		if (!data.groups || !Array.isArray(data.groups))
 			throw new Error('Must provide an array of groups.');
 		var groups = data.groups;
-		groups = groups.map(g => g instanceof Group ? g.id : g);
+		groups = groups.map((g) => (g instanceof Group ? g.id : g));
 
 		try {
 			var resp = await this.handle(
 				ROUTES[this.#_version].REMOVE_MEMBER_GROUPS(data.member),
-				{token, body: groups}
-			)
-		} catch(e) {
+				{
+					token,
+					body: groups,
+				},
+			);
+		} catch (e) {
 			throw e;
 		}
 
@@ -386,26 +478,30 @@ class PKAPI {
 	}
 
 	async setMemberGroups(data: {
-		token?: string,
-		member: string,
-		groups: string[] | Group[]
+		token?: string;
+		member: string;
+		groups: string[] | Group[];
 	}) {
-		if(this.version < 2) throw new Error("Groups are only available for API version 2.");
+		if (this.version < 2)
+			throw new Error('Groups are only available for API version 2.');
 
 		var token = this.#token || data.token;
-		if(!token) throw new Error('POST requires a token.');
-		if(!data.member) throw new Error('Must provide a member ID.');
-		if(!data.groups || !Array.isArray(data.groups))
+		if (!token) throw new Error('POST requires a token.');
+		if (!data.member) throw new Error('Must provide a member ID.');
+		if (!data.groups || !Array.isArray(data.groups))
 			throw new Error('Must provide an array of groups.');
 		var groups = data.groups;
-		groups = groups.map(g => g instanceof Group ? g.id : g);
+		groups = groups.map((g) => (g instanceof Group ? g.id : g));
 
 		try {
 			var resp = await this.handle(
 				ROUTES[this.#_version].SET_MEMBER_GROUPS(data.member),
-				{token, body: groups}
-			)
-		} catch(e) {
+				{
+					token,
+					body: groups,
+				},
+			);
+		} catch (e) {
 			throw e;
 		}
 
@@ -413,74 +509,110 @@ class PKAPI {
 	}
 
 	async getMemberGuildSettings(data: {
-		token?: string,
-		member: string,
-		guild: string
+		token?: string;
+		member: string;
+		guild: string;
 	}) {
-		if(this.version < 2) throw new Error("Guild settings are only available for API version 2.");
+		if (this.version < 2)
+			throw new Error('Guild settings are only available for API version 2.');
 
 		var token = this.#token || data.token;
-		if(!token) throw new Error("Getting guild settings requires a token.");
-		if(!data.member) throw new Error("Must provide a member ID.");
-		if(!data.guild) throw new Error("Must provide a guild ID.");
+		if (!token) throw new Error('Getting guild settings requires a token.');
+		if (!data.member) throw new Error('Must provide a member ID.');
+		if (!data.guild) throw new Error('Must provide a guild ID.');
 
 		try {
 			var resp = await this.handle(
-				ROUTES[this.#_version].GET_MEMBER_GUILD_SETTINGS(data.member, data.guild),
-				{token}
+				ROUTES[this.#_version].GET_MEMBER_GUILD_SETTINGS(
+					data.member,
+					data.guild,
+				),
+				{
+					token,
+				},
 			);
-		} catch(e) {
+		} catch (e) {
 			throw e;
 		}
 
-		return new MemberGuildSettings(this, {...resp.data, guild: data.guild, member: data.member});
+		return new MemberGuildSettings(this, {
+			...resp.data,
+			guild: data.guild,
+			member: data.member,
+		});
 	}
 
-	async patchMemberGuildSettings(data: RequestData<Partial<IMemberGuildSettings>>) {
-		if(this.version < 2) throw new Error("Guild settings are only available for API version 2.");
+	async patchMemberGuildSettings(
+		data: RequestData<Partial<IMemberGuildSettings>>,
+	) {
+		if (this.version < 2)
+			throw new Error('Guild settings are only available for API version 2.');
 
 		var token = this.#token || data.token;
-		if(!token) throw new Error("Getting guild settings requires a token.");
-		if(!data.member) throw new Error("Must provide a member ID.");
-		if(!data.guild) throw new Error("Must provide a guild ID.");
+		if (!token) throw new Error('Getting guild settings requires a token.');
+		if (!data.member) throw new Error('Must provide a member ID.');
+		if (!data.guild) throw new Error('Must provide a guild ID.');
 
 		try {
-			var settings = data instanceof MemberGuildSettings ? data : new MemberGuildSettings(this, data);
+			var settings =
+				data instanceof MemberGuildSettings
+					? data
+					: new MemberGuildSettings(this, data);
 			var body = await settings.verify();
 			var resp = await this.handle(
-				ROUTES[this.#_version].PATCH_MEMBER_GUILD_SETTINGS(data.member, data.guild),
-				{token, body}
+				ROUTES[this.#_version].PATCH_MEMBER_GUILD_SETTINGS(
+					data.member,
+					data.guild,
+				),
+				{
+					token,
+					body,
+				},
 			);
-		} catch(e) {
+		} catch (e) {
 			throw e;
 		}
 
-		return new MemberGuildSettings(this, {...resp.data, guild: data.guild, member: data.member});
+		return new MemberGuildSettings(this, {
+			...resp.data,
+			guild: data.guild,
+			member: data.member,
+		});
 	}
 
 	/*
-	**			GROUP FUNCTIONS
-	*/
+	 **			GROUP FUNCTIONS
+	 */
 
 	async createGroup(data: RequestData<Partial<IGroup>>) {
-		if(this.version < 2) throw new Error("Groups are only available for API version 2.");
+		if (this.version < 2)
+			throw new Error('Groups are only available for API version 2.');
 
 		var token = this.#token || data.token;
-		if(!token) throw new Error('POST requires a token.');
+		if (!token) throw new Error('POST requires a token.');
 
 		try {
 			var group = new Group(this, data);
 			var body = await group.verify();
-			var resp = await this.handle(ROUTES[this.#_version].ADD_GROUP(), {token, body});
-		} catch(e) {
+			var resp = await this.handle(ROUTES[this.#_version].ADD_GROUP(), {
+				token,
+				body,
+			});
+		} catch (e) {
 			throw e;
 		}
 
 		return new Group(this, resp.data);
 	}
 
-	async getGroups(data: { token?: string, system?: string, with_members?: boolean, raw?: boolean }) {
-		if(this.version < 2) throw new Error("Groups are only available for API version 2.");
+	async getGroups(data: {
+		token?: string;
+		system?: string;
+		with_members?: boolean;
+		raw?: boolean;
+	}) {
+		if (this.version < 2)
+			throw new Error('Groups are only available for API version 2.');
 
 		var token = this.#token || data.token;
 		var system = data.system ?? '@me';
@@ -488,46 +620,61 @@ class PKAPI {
 
 		var groups;
 		try {
-			var resp = await this.handle(ROUTES[this.#_version].GET_GROUPS(system, with_members), {token});
-			if(with_members && !data.raw) {
-				var memb_resp = await this.handle(ROUTES[this.#_version].GET_MEMBERS(system), {token});
-				var membs: Map<string, Member> = new Map(memb_resp.data.map((m: IMember) => [m.uuid, new Member(this, m)]));
+			var resp = await this.handle(
+				ROUTES[this.#_version].GET_GROUPS(system, with_members),
+				{
+					token,
+				},
+			);
+			if (with_members && !data.raw) {
+				var memb_resp = await this.handle(
+					ROUTES[this.#_version].GET_MEMBERS(system),
+					{ token },
+				);
+				var membs: Map<string, Member> = new Map(
+					memb_resp.data.map((m: IMember) => [m.uuid, new Member(this, m)]),
+				);
 				groups = [];
-				for(var g of resp.data) {
+				for (var g of resp.data) {
 					var members = new Map();
-					for(var m of g.members) {
+					for (var m of g.members) {
 						var grabbed: Member | undefined = membs.get(m);
-						if(grabbed) members.set(grabbed.id, grabbed);
+						if (grabbed) members.set(grabbed.id, grabbed);
 					}
 					g.members = members;
 					groups.push(new Group(this, g));
 				}
 			}
-		} catch(e) {
+		} catch (e) {
 			throw e;
 		}
 
-		if(!with_members || data.raw) groups = resp.data.map((g: IGroup) => new Group(this, g));
+		if (!with_members || data.raw)
+			groups = resp.data.map((g: IGroup) => new Group(this, g));
 
 		return new Map<string, Group>(groups.map((g: IGroup) => [g.id, g]));
 	}
 
 	async getGroup(data: {
-		token?: string,
-		group: string,
-		fetch_members?: boolean
+		token?: string;
+		group: string;
+		fetch_members?: boolean;
 	}) {
-		if(this.version < 2) throw new Error("Groups are only available for API version 2.");
+		if (this.version < 2)
+			throw new Error('Groups are only available for API version 2.');
 
 		var token = this.#token || data.token;
-		if(!data.group) throw new Error('Must provide group ID.');
+		if (!data.group) throw new Error('Must provide group ID.');
 
 		try {
-			var resp = await this.handle(ROUTES[this.#_version].GET_GROUP(data.group), {token});
+			var resp = await this.handle(
+				ROUTES[this.#_version].GET_GROUP(data.group),
+				{ token },
+			);
 			var group = new Group(this, resp.data);
 
-			if(data.fetch_members) group.members = await group.getMembers();
-		} catch(e) {
+			if (data.fetch_members) group.members = await group.getMembers();
+		} catch (e) {
 			throw e;
 		}
 
@@ -535,48 +682,59 @@ class PKAPI {
 	}
 
 	async patchGroup(data: RequestData<Partial<IGroup> & { group: string }>) {
-		if(this.version < 2) throw new Error("Groups are only available for API version 2.");
+		if (this.version < 2)
+			throw new Error('Groups are only available for API version 2.');
 
-		if(data.group == null) throw new Error("Must provide a group ID.");
+		if (data.group == null) throw new Error('Must provide a group ID.');
 		var token = this.#token || data.token;
-		if(!token) throw new Error("PATCH requires a token.");
+		if (!token) throw new Error('PATCH requires a token.');
 
 		try {
 			var group = data instanceof Group ? data : new Group(this, data);
 			var body = await group.verify();
-			var resp = await this.handle(ROUTES[this.#_version].PATCH_GROUP(data.group), {token, body});
-		} catch(e) {
+			var resp = await this.handle(
+				ROUTES[this.#_version].PATCH_GROUP(data.group),
+				{ token, body },
+			);
+		} catch (e) {
 			throw e;
 		}
 
 		return new Group(this, resp.data);
 	}
 
-	async deleteGroup(data: { token?: string, group: string }) {
-		if(this.version < 2) throw new Error("Groups are only available for API version 2.");
+	async deleteGroup(data: { token?: string; group: string }) {
+		if (this.version < 2)
+			throw new Error('Groups are only available for API version 2.');
 
-		if(data.group == null) throw new Error("Must provide a group ID.");
+		if (data.group == null) throw new Error('Must provide a group ID.');
 		var token = this.#token || data.token;
-		if(!token) throw new Error("DELETE requires a token.");
+		if (!token) throw new Error('DELETE requires a token.');
 
 		try {
-			await this.handle(ROUTES[this.#_version].DELETE_GROUP(data.group), {token});
-		} catch(e) {
+			await this.handle(ROUTES[this.#_version].DELETE_GROUP(data.group), {
+				token,
+			});
+		} catch (e) {
 			throw e;
 		}
 
 		return;
 	}
 
-	async getGroupMembers(data: { token?: string, group: string }) {
-		if(this.version < 2) throw new Error("Groups are only available for API version 2.");
+	async getGroupMembers(data: { token?: string; group: string }) {
+		if (this.version < 2)
+			throw new Error('Groups are only available for API version 2.');
 
 		var token = this.#token || data.token;
-		if(!data.group) throw new Error("Must provide a group ID.");
+		if (!data.group) throw new Error('Must provide a group ID.');
 
 		try {
-			var resp = await this.handle(ROUTES[this.#_version].GET_GROUP_MEMBERS(data.group), { token });
-		} catch(e) {
+			var resp = await this.handle(
+				ROUTES[this.#_version].GET_GROUP_MEMBERS(data.group),
+				{ token },
+			);
+		} catch (e) {
 			throw e;
 		}
 
@@ -585,26 +743,30 @@ class PKAPI {
 	}
 
 	async addGroupMembers(data: {
-		token?: string,
-		group: string,
-		members: string[] | Member[]
+		token?: string;
+		group: string;
+		members: string[] | Member[];
 	}) {
-		if(this.version < 2) throw new Error("Groups are only available for API version 2.");
+		if (this.version < 2)
+			throw new Error('Groups are only available for API version 2.');
 
 		var token = this.#token || data.token;
-		if(!token) throw new Error('POST requires a token.');
-		if(!data.group) throw new Error('Must provide a group ID.');
-		if(!data.members || !Array.isArray(data.members))
+		if (!token) throw new Error('POST requires a token.');
+		if (!data.group) throw new Error('Must provide a group ID.');
+		if (!data.members || !Array.isArray(data.members))
 			throw new Error('Must provide an array of members.');
 		var members = data.members;
-		members = members.map(m => m instanceof Member ? m.id : m);
+		members = members.map((m) => (m instanceof Member ? m.id : m));
 
 		try {
 			var resp = await this.handle(
 				ROUTES[this.#_version].ADD_GROUP_MEMBERS(data.group),
-				{token, body: members}
-			)
-		} catch(e) {
+				{
+					token,
+					body: members,
+				},
+			);
+		} catch (e) {
 			throw e;
 		}
 
@@ -612,26 +774,30 @@ class PKAPI {
 	}
 
 	async removeGroupMembers(data: {
-		token?: string,
-		group: string,
-		members: string[] | Member[]
+		token?: string;
+		group: string;
+		members: string[] | Member[];
 	}) {
-		if(this.version < 2) throw new Error("Groups are only available for API version 2.");
+		if (this.version < 2)
+			throw new Error('Groups are only available for API version 2.');
 
 		var token = this.#token || data.token;
-		if(!token) throw new Error('POST requires a token.');
-		if(!data.group) throw new Error('Must provide a group ID.');
-		if(!data.members || !Array.isArray(data.members))
+		if (!token) throw new Error('POST requires a token.');
+		if (!data.group) throw new Error('Must provide a group ID.');
+		if (!data.members || !Array.isArray(data.members))
 			throw new Error('Must provide an array of members.');
 		var members = data.members;
-		members = members.map(m => m instanceof Member ? m.id : m);
+		members = members.map((m) => (m instanceof Member ? m.id : m));
 
 		try {
 			var resp = await this.handle(
 				ROUTES[this.#_version].REMOVE_GROUP_MEMBERS(data.group),
-				{token, body: members}
-			)
-		} catch(e) {
+				{
+					token,
+					body: members,
+				},
+			);
+		} catch (e) {
 			throw e;
 		}
 
@@ -639,26 +805,30 @@ class PKAPI {
 	}
 
 	async setGroupMembers(data: {
-		token?: string,
-		group: string,
-		members: string[] | Member[]
+		token?: string;
+		group: string;
+		members: string[] | Member[];
 	}) {
-		if(this.version < 2) throw new Error("Groups are only available for API version 2.");
+		if (this.version < 2)
+			throw new Error('Groups are only available for API version 2.');
 
 		var token = this.#token || data.token;
-		if(!token) throw new Error('POST requires a token.');
-		if(!data.group) throw new Error('Must provide a group ID.');
-		if(!data.members || !Array.isArray(data.members))
+		if (!token) throw new Error('POST requires a token.');
+		if (!data.group) throw new Error('Must provide a group ID.');
+		if (!data.members || !Array.isArray(data.members))
 			throw new Error('Must provide an array of members.');
 		var members = data.members;
-		members = members.map(m => m instanceof Member ? m.id : m);
+		members = members.map((m) => (m instanceof Member ? m.id : m));
 
 		try {
 			var resp = await this.handle(
 				ROUTES[this.#_version].SET_GROUP_MEMBERS(data.group),
-				{token, body: members}
-			)
-		} catch(e) {
+				{
+					token,
+					body: members,
+				},
+			);
+		} catch (e) {
 			throw e;
 		}
 
@@ -666,189 +836,231 @@ class PKAPI {
 	}
 
 	/*
-	**			SWITCH FUNCTIONS
-	*/
+	 **			SWITCH FUNCTIONS
+	 */
 
 	async createSwitch(data: RequestData<Partial<ISwitch>>) {
 		var token = this.#token || data.token;
-		if(!token) throw new Error("POST requires a token.");
+		if (!token) throw new Error('POST requires a token.');
 
 		var body: {
-			members: string[]
+			members: string[];
 		} = {
-			members: []
+			members: [],
 		};
 
-		if(data.members) {
-			if(Array.isArray(data.members)) {
+		if (data.members) {
+			if (Array.isArray(data.members)) {
 				body.members = data.members;
 			} else {
 				body.members = Object.values(data.members).map((m: IMember) => m.id);
 			}
 		}
 		try {
-			var resp = await this.handle(ROUTES[this.#_version].ADD_SWITCH(), {token, body})
-		} catch(e) {
-			throw e
+			var resp = await this.handle(ROUTES[this.#_version].ADD_SWITCH(), {
+				token,
+				body,
+			});
+		} catch (e) {
+			throw e;
 		}
 
-		if(this.#_version < 2) return;
+		if (this.#_version < 2) return;
 
 		return new Switch(this, {
 			...resp.data,
-			members: new Map(resp.data.members.map((m: IMember) => [m.id, new Member(this, m)]))
+			members: new Map(
+				resp.data.members.map((m: IMember) => [m.id, new Member(this, m)]),
+			),
 		});
 	}
 
 	async getSwitches(data: {
-		token?: string,
-		system?: string,
-		raw?: boolean,
-		before?: Date,
-		limit?: number,
+		token?: string;
+		system?: string;
+		raw?: boolean;
+		before?: Date;
+		limit?: number;
 	}) {
 		var system = data.system ?? '@me';
 		var token = this.#token || data.token;
 		var { before, limit } = data;
 		try {
-			var resp = await this.handle(ROUTES[this.#_version].GET_SWITCHES(system, before, limit), {token});
-			if(!data.raw) {
-				var memb_resp = await this.handle(ROUTES[this.#_version].GET_MEMBERS(system), {token});
-				var membs = new Map(memb_resp.data.map((m: IMember) => [m.id, new Member(this, m)]));
+			var resp = await this.handle(
+				ROUTES[this.#_version].GET_SWITCHES(system, before, limit),
+				{
+					token,
+				},
+			);
+			if (!data.raw) {
+				var memb_resp = await this.handle(
+					ROUTES[this.#_version].GET_MEMBERS(system),
+					{ token },
+				);
+				var membs = new Map(
+					memb_resp.data.map((m: IMember) => [m.id, new Member(this, m)]),
+				);
 				var switches = [];
-				for(var s of resp.data) {
+				for (var s of resp.data) {
 					var members = new Map();
-					for(var m of s.members) if(membs.get(m)) members.set(m, membs.get(m));
+					for (var m of s.members)
+						if (membs.get(m)) members.set(m, membs.get(m));
 					s.members = members;
 					switches.push(new Switch(this, s));
 				}
 			}
-		} catch(e) {
+		} catch (e) {
 			throw e;
 		}
 
-		if(data.raw) {
+		if (data.raw) {
 			switches = resp.data.map((s: ISwitch) => new Switch(this, s));
 		}
 
-		if(this.#_version < 2) return switches;
+		if (this.#_version < 2) return switches;
 		else return new Map(switches.map((s: ISwitch) => [s.id, s]));
 	}
 
-	async getSwitch(data: {
-		token?: string,
-		system?: string,
-		switch: string
-	}) {
-		if(this.version < 2) throw new Error("Individual switches are only available for API version 2.");
+	async getSwitch(data: { token?: string; system?: string; switch: string }) {
+		if (this.version < 2)
+			throw new Error(
+				'Individual switches are only available for API version 2.',
+			);
 
 		var token = this.#token || data.token;
 		var system = data.system ?? '@me';
-		if(!data.switch) throw new Error("Must provide a switch ID.");
+		if (!data.switch) throw new Error('Must provide a switch ID.');
 
 		try {
-			var resp = await this.handle(ROUTES[this.#_version].GET_SWITCH(system, data.switch), {token})
-		} catch(e) {
+			var resp = await this.handle(
+				ROUTES[this.#_version].GET_SWITCH(system, data.switch),
+				{
+					token,
+				},
+			);
+		} catch (e) {
 			throw e;
 		}
 
 		return new Switch(this, {
 			...resp.data,
-			members: new Map(resp.data.members.map((m: IMember) => [m.id, new Member(this, m)]))
+			members: new Map(
+				resp.data.members.map((m: IMember) => [m.id, new Member(this, m)]),
+			),
 		});
 	}
 
-	async getFronters(data: {
-		token?: string,
-		system?: string
-	}) {
+	async getFronters(data: { token?: string; system?: string }) {
 		var token = this.#token || data.token;
 		var system = data.system ?? '@me';
 		try {
-			var resp = await this.handle(ROUTES[this.#_version].GET_FRONTERS(system), {token});
-		} catch(e) {
+			var resp = await this.handle(
+				ROUTES[this.#_version].GET_FRONTERS(system),
+				{ token },
+			);
+		} catch (e) {
 			throw e;
 		}
 
-		if(resp.status == 204) return undefined;
+		if (resp.status == 204) return undefined;
 
 		return new Switch(this, {
 			...resp.data,
-			members: new Map(resp.data.members.map((m: IMember) => [m.id, new Member(this, m)]))
+			members: new Map(
+				resp.data.members.map((m: IMember) => [m.id, new Member(this, m)]),
+			),
 		});
 	}
 
 	async patchSwitchTimestamp(data: {
-		token?: string,
-		switch: string,
-		timestamp: string | Date
+		token?: string;
+		switch: string;
+		timestamp: string | Date;
 	}) {
-		if(this.version < 2) throw new Error("Individual switches are only available for API version 2.");
+		if (this.version < 2)
+			throw new Error(
+				'Individual switches are only available for API version 2.',
+			);
 
 		var token = this.#token || data.token;
-		if(!token) throw new Error('PATCH requires a token.');
-		if(!data.switch) throw new Error('Must provide a switch ID.');
-		if(!data.timestamp) throw new Error('Must provide a timestamp.');
+		if (!token) throw new Error('PATCH requires a token.');
+		if (!data.switch) throw new Error('Must provide a switch ID.');
+		if (!data.timestamp) throw new Error('Must provide a timestamp.');
 
 		try {
-			var sw = await this.handle(ROUTES[this.#_version].PATCH_SWITCH(data.switch), {
-				token,
-				body: {timestamp: data.timestamp}
-			});
-		} catch(e) {
+			var sw = await this.handle(
+				ROUTES[this.#_version].PATCH_SWITCH(data.switch),
+				{
+					token,
+					body: { timestamp: data.timestamp },
+				},
+			);
+		} catch (e) {
 			throw e;
 		}
 
 		return new Switch(this, {
 			...sw.data,
-			members: new Map(sw.data.members.map((m: IMember) => [m.id, new Member(this, m)]))
+			members: new Map(
+				sw.data.members.map((m: IMember) => [m.id, new Member(this, m)]),
+			),
 		});
 	}
 
 	async patchSwitchMembers(data: {
-		token?: string,
-		switch: string,
-		members?: string[]
+		token?: string;
+		switch: string;
+		members?: string[];
 	}) {
-		if(this.version < 2) throw new Error("Individual switches are only available for API version 2.");
+		if (this.version < 2)
+			throw new Error(
+				'Individual switches are only available for API version 2.',
+			);
 
 		var token = this.#token || data.token;
-		if(!token) throw new Error('PATCH requires a token.');
-		if(!data.switch) throw new Error('Must provide a switch ID.');
+		if (!token) throw new Error('PATCH requires a token.');
+		if (!data.switch) throw new Error('Must provide a switch ID.');
 
 		try {
 			var s = data instanceof Switch ? data : new Switch(this, data);
 			var sv = await s.verify();
-			if(sv.members && !Array.isArray(sv.members))
+			if (sv.members && !Array.isArray(sv.members))
 				throw new Error('Members must be an array or map if provided.');
 
-			var sw = await this.handle(ROUTES[this.#_version].PATCH_SWITCH_MEMBERS(data.switch), {
-				token,
-				body: sv.members ?? []
-			});
-		} catch(e) {
+			var sw = await this.handle(
+				ROUTES[this.#_version].PATCH_SWITCH_MEMBERS(data.switch),
+				{
+					token,
+					body: sv.members ?? [],
+				},
+			);
+		} catch (e) {
 			throw e;
 		}
 
 		return new Switch(this, {
 			...sw.data,
-			members: new Map(sw.data.members.map((m: IMember) => [m.id, new Member(this, m)]))
+			members: new Map(
+				sw.data.members.map((m: IMember) => [m.id, new Member(this, m)]),
+			),
 		});
 	}
 
-	async deleteSwitch(data: {
-		token?: string,
-		switch: string
-	}) {
-		if(this.version < 2) throw new Error("Individual switches are only available for API version 2.");
+	async deleteSwitch(data: { token?: string; switch: string }) {
+		if (this.version < 2)
+			throw new Error(
+				'Individual switches are only available for API version 2.',
+			);
 
 		var token = this.#token || data.token;
-		if(!token) throw new Error('DELETE requires a token.');
-		if(!data.switch) throw new Error('Must provide a switch ID.');
+		if (!token) throw new Error('DELETE requires a token.');
+		if (!data.switch) throw new Error('Must provide a switch ID.');
 
 		try {
-			await this.handle(ROUTES[this.#_version].DELETE_SWITCH(data.switch), {token});
-		} catch(e) {
+			await this.handle(ROUTES[this.#_version].DELETE_SWITCH(data.switch), {
+				token,
+			});
+		} catch (e) {
 			throw e;
 		}
 
@@ -856,18 +1068,18 @@ class PKAPI {
 	}
 
 	/*
-	** 			MISC FUNCTIONS
-	*/
+	 ** 			MISC FUNCTIONS
+	 */
 
-	async getMessage(data: {
-		token?: string,
-		message: string
-	}) {
-		if(data.message == null) throw new Error('Must provide a message ID.');
+	async getMessage(data: { token?: string; message: string }) {
+		if (data.message == null) throw new Error('Must provide a message ID.');
 		var token = this.#token || data.token;
 		try {
-			var resp = await this.handle(ROUTES[this.#_version].GET_MESSAGE(data.message), {token});
-		} catch(e) {
+			var resp = await this.handle(
+				ROUTES[this.#_version].GET_MESSAGE(data.message),
+				{ token },
+			);
+		} catch (e) {
 			throw e;
 		}
 
@@ -875,35 +1087,38 @@ class PKAPI {
 	}
 
 	/*
-	**			BASE STUFF
-	*/
+	 **			BASE STUFF
+	 */
 
-	async handle(path: any, options?: {
-		token?: string,
-		headers?: any,
-		body?: any
-	}) {
+	async handle(
+		path: any,
+		options?: {
+			token?: string;
+			headers?: any;
+			body?: any;
+		},
+	) {
 		var { route, method } = path;
 		var headers = options?.headers || {};
 		var request: {
-			method?: any,
-			headers?: any,
-			data?: any
-		} = {method, headers};
+			method?: any;
+			headers?: any;
+			data?: any;
+		} = { method, headers };
 		var token = this.#token || options?.token;
-		if(token) request.headers["Authorization"] = token;
+		if (token) request.headers['Authorization'] = token;
 
-		if(options?.body) {
-			request.headers["content-type"] = "application/json";
+		if (options?.body) {
+			request.headers['content-type'] = 'application/json';
 			request.data = JSON.stringify(options.body);
 		}
 
-		if(this.version == 1 && !this.#version_warning) {
+		if (this.version == 1 && !this.#version_warning) {
 			console.warn(
 				'WARNING: API version 1 is considered officially deprecated. ' +
-				'Support for this API version may be removed from this wrapper ' +
-				'in a future version. Some methods may not fully work for v1 as well. '+
-				'USE v1 at your own risk!'
+					'Support for this API version may be removed from this wrapper ' +
+					'in a future version. Some methods may not fully work for v1 as well. ' +
+					'USE v1 at your own risk!',
 			);
 			this.#version_warning = true;
 		}
@@ -918,7 +1133,7 @@ class PKAPI {
 					continue;
 				}
 
-				if(this.#debug) console.log(e)
+				if (this.#debug) console.log(e);
 				throw new APIError(this, e.response);
 			}
 
@@ -962,7 +1177,7 @@ class PKAPI {
 	}
 
 	get debug() {
-		return this.#debug
+		return this.#debug;
 	}
 
 	set debug(b) {
@@ -980,38 +1195,27 @@ class PKAPI {
 export default PKAPI;
 export {
 	PKAPI,
-
 	APIError,
-
 	Group,
 	IGroup,
-
 	Member,
 	IMember,
 	ProxyTag,
-
 	MemberGuildSettings,
 	IMemberGuildSettings,
-
 	Message,
 	IMessage,
-
 	Switch,
 	ISwitch,
-
 	System,
 	ISystem,
-
 	SystemAutoproxySettings,
 	ISystemAutoproxySettings,
-
 	SystemConfig,
 	ISystemConfig,
-
 	SystemGuildSettings,
 	ISystemGuildSettings,
-
 	BaseRateLimiter,
 	NoOpRateLimiter,
 	DefaultRateLimiter,
-}
+};

--- a/lib/routes.ts
+++ b/lib/routes.ts
@@ -1,81 +1,174 @@
 const ROUTES: any = {
 	1: {
-		GET_SYSTEM: (sid: string) => ({method: 'GET', route: `/s/${sid}`}),
-		GET_OWN_SYSTEM: () => ({method: 'GET', route: `/s`}),
-		GET_ACCOUNT: (aid: string) => ({method: 'GET', route: `/a/${aid}`}),
-		PATCH_SYSTEM: () => ({method: 'PATCH', route: `/s`}),
+		GET_SYSTEM: (sid: string) => ({ method: 'GET', route: `/s/${sid}` }),
+		GET_OWN_SYSTEM: () => ({ method: 'GET', route: `/s` }),
+		GET_ACCOUNT: (aid: string) => ({ method: 'GET', route: `/a/${aid}` }),
+		PATCH_SYSTEM: () => ({ method: 'PATCH', route: `/s` }),
 
-		ADD_MEMBER: () => ({method: 'POST', route: `/m`}),
-		GET_MEMBER: (mid: string) => ({method: 'GET', route: `/m/${mid}`}),
-		GET_MEMBERS: (sid: string) => ({method: 'GET', route: `/s/${sid}/members`}),
-		PATCH_MEMBER: (mid: string) => ({method: 'PATCH', route: `/m/${mid}`}),
-		DELETE_MEMBER: (mid: string) => ({method: 'DELETE', route: `/m/${mid}`}),
+		ADD_MEMBER: () => ({ method: 'POST', route: `/m` }),
+		GET_MEMBER: (mid: string) => ({ method: 'GET', route: `/m/${mid}` }),
+		GET_MEMBERS: (sid: string) => ({
+			method: 'GET',
+			route: `/s/${sid}/members`,
+		}),
+		PATCH_MEMBER: (mid: string) => ({ method: 'PATCH', route: `/m/${mid}` }),
+		DELETE_MEMBER: (mid: string) => ({ method: 'DELETE', route: `/m/${mid}` }),
 
-		ADD_SWITCH: () => ({method: 'POST', route: `/s/switches`}),
-		GET_SWITCHES: (sid: string) => ({method: 'GET', route: `/s/${sid}/switches`}),
-		GET_FRONTERS: (sid: string) => ({method: 'GET', route: `/s/${sid}/fronters`}),
+		ADD_SWITCH: () => ({ method: 'POST', route: `/s/switches` }),
+		GET_SWITCHES: (sid: string) => ({
+			method: 'GET',
+			route: `/s/${sid}/switches`,
+		}),
+		GET_FRONTERS: (sid: string) => ({
+			method: 'GET',
+			route: `/s/${sid}/fronters`,
+		}),
 
-		GET_MESSAGE: (mid: string) => ({method: 'GET', route: `/msg/${mid}`})
+		GET_MESSAGE: (mid: string) => ({ method: 'GET', route: `/msg/${mid}` }),
 	},
 	2: {
-		GET_SYSTEM: (sid: string) => ({method: 'GET', route: `/systems/${sid}`}),
-		GET_OWN_SYSTEM: () => ({method: 'GET', route: `/systems/@me`}),
-		GET_ACCOUNT: (sid: string) => ({method: 'GET', route: `/systems/${sid}`}),
+		GET_SYSTEM: (sid: string) => ({ method: 'GET', route: `/systems/${sid}` }),
+		GET_OWN_SYSTEM: () => ({ method: 'GET', route: `/systems/@me` }),
+		GET_ACCOUNT: (sid: string) => ({ method: 'GET', route: `/systems/${sid}` }),
 
-		ADD_MEMBER: () => ({method: 'POST', route: `/members`}),
-		GET_MEMBER: (mid: string) => ({method: 'GET', route: `/members/${mid}`}),
-		GET_MEMBERS: (sid: string) => ({method: 'GET', route: `/systems/${sid}/members`}),
-		PATCH_MEMBER: (mid: string) => ({method: 'PATCH', route: `/members/${mid}`}),
-		DELETE_MEMBER: (mid: string) => ({method: 'DELETE', route: `/members/${mid}`}),
+		ADD_MEMBER: () => ({ method: 'POST', route: `/members` }),
+		GET_MEMBER: (mid: string) => ({ method: 'GET', route: `/members/${mid}` }),
+		GET_MEMBERS: (sid: string) => ({
+			method: 'GET',
+			route: `/systems/${sid}/members`,
+		}),
+		PATCH_MEMBER: (mid: string) => ({
+			method: 'PATCH',
+			route: `/members/${mid}`,
+		}),
+		DELETE_MEMBER: (mid: string) => ({
+			method: 'DELETE',
+			route: `/members/${mid}`,
+		}),
 
-		ADD_GROUP: () => ({method: 'POST', route: `/groups`}),
-		GET_GROUPS: (sid: string, members?: boolean) => ({method: 'GET', route: `/systems/${sid}/groups?with_members=${members ? 'true' : 'false'}`}),
-		GET_GROUP: (gid: string) => ({method: 'GET', route: `/groups/${gid}`}),
-		PATCH_GROUP: (gid: string) => ({method: 'PATCH', route: `/groups/${gid}`}),
-		DELETE_GROUP: (gid: string) => ({method: 'DELETE', route: `/groups/${gid}`}),
+		ADD_GROUP: () => ({ method: 'POST', route: `/groups` }),
+		GET_GROUPS: (sid: string, members?: boolean) => ({
+			method: 'GET',
+			route: `/systems/${sid}/groups?with_members=${members ? 'true' : 'false'}`,
+		}),
+		GET_GROUP: (gid: string) => ({ method: 'GET', route: `/groups/${gid}` }),
+		PATCH_GROUP: (gid: string) => ({
+			method: 'PATCH',
+			route: `/groups/${gid}`,
+		}),
+		DELETE_GROUP: (gid: string) => ({
+			method: 'DELETE',
+			route: `/groups/${gid}`,
+		}),
 
-		GET_GROUP_MEMBERS: (gid: string) => ({method: 'GET', route: `/groups/${gid}/members`}),
-		ADD_GROUP_MEMBERS: (gid: string) => ({method: 'POST', route: `/groups/${gid}/members/add`}),
-		REMOVE_GROUP_MEMBERS: (gid: string) => ({method: 'POST', route: `/groups/${gid}/members/remove`}),
-		SET_GROUP_MEMBERS: (gid: string) => ({method: 'POST', route: `/groups/${gid}/members/overwrite`}),
+		GET_GROUP_MEMBERS: (gid: string) => ({
+			method: 'GET',
+			route: `/groups/${gid}/members`,
+		}),
+		ADD_GROUP_MEMBERS: (gid: string) => ({
+			method: 'POST',
+			route: `/groups/${gid}/members/add`,
+		}),
+		REMOVE_GROUP_MEMBERS: (gid: string) => ({
+			method: 'POST',
+			route: `/groups/${gid}/members/remove`,
+		}),
+		SET_GROUP_MEMBERS: (gid: string) => ({
+			method: 'POST',
+			route: `/groups/${gid}/members/overwrite`,
+		}),
 
-		GET_MEMBER_GROUPS: (mid: string) => ({method: 'GET', route: `/members/${mid}/groups`}),
-		ADD_MEMBER_GROUPS: (mid: string) => ({method: 'POST', route: `/members/${mid}/groups/add`}),
-		REMOVE_MEMBER_GROUPS: (mid: string) => ({method: 'POST', route: `/members/${mid}/groups/remove`}),
-		SET_MEMBER_GROUPS: (mid: string) => ({method: 'POST', route: `/members/${mid}/groups/overwrite`}),
+		GET_MEMBER_GROUPS: (mid: string) => ({
+			method: 'GET',
+			route: `/members/${mid}/groups`,
+		}),
+		ADD_MEMBER_GROUPS: (mid: string) => ({
+			method: 'POST',
+			route: `/members/${mid}/groups/add`,
+		}),
+		REMOVE_MEMBER_GROUPS: (mid: string) => ({
+			method: 'POST',
+			route: `/members/${mid}/groups/remove`,
+		}),
+		SET_MEMBER_GROUPS: (mid: string) => ({
+			method: 'POST',
+			route: `/members/${mid}/groups/overwrite`,
+		}),
 
-		ADD_SWITCH: () => ({method: 'POST', route: `/systems/@me/switches`}),
+		ADD_SWITCH: () => ({ method: 'POST', route: `/systems/@me/switches` }),
 		GET_SWITCHES: (sid: string, before: Date, limit: number) => {
-			var tmp = {method: 'GET', route: `/systems/${sid}/switches`};
+			var tmp = { method: 'GET', route: `/systems/${sid}/switches` };
 			var adds = [];
 
-			if(before) adds.push(`before=${before.toISOString()}`);
-			if(limit) adds.push(`limit=${limit}`);
+			if (before) adds.push(`before=${before.toISOString()}`);
+			if (limit) adds.push(`limit=${limit}`);
 
-			if(adds.length) tmp.route += `?${adds.join('&')}`;
+			if (adds.length) tmp.route += `?${adds.join('&')}`;
 
 			return tmp;
 		},
-		GET_FRONTERS: (sid: string) => ({method: 'GET', route: `/systems/${sid}/fronters`}),
-		GET_SWITCH: (sid: string, swid: string) => ({method: 'GET', route: `/systems/${sid}/switches/${swid}`}),
-		PATCH_SWITCH: (swid: string) => ({method: 'PATCH', route: `/systems/@me/switches/${swid}`}),
-		PATCH_SWITCH_MEMBERS: (swid: string) => ({method: 'PATCH', route: `/systems/@me/switches/${swid}/members`}),
-		DELETE_SWITCH: (swid: string) => ({method: 'DELETE', route: `/systems/@me/switches/${swid}`}),
+		GET_FRONTERS: (sid: string) => ({
+			method: 'GET',
+			route: `/systems/${sid}/fronters`,
+		}),
+		GET_SWITCH: (sid: string, swid: string) => ({
+			method: 'GET',
+			route: `/systems/${sid}/switches/${swid}`,
+		}),
+		PATCH_SWITCH: (swid: string) => ({
+			method: 'PATCH',
+			route: `/systems/@me/switches/${swid}`,
+		}),
+		PATCH_SWITCH_MEMBERS: (swid: string) => ({
+			method: 'PATCH',
+			route: `/systems/@me/switches/${swid}/members`,
+		}),
+		DELETE_SWITCH: (swid: string) => ({
+			method: 'DELETE',
+			route: `/systems/@me/switches/${swid}`,
+		}),
 
-		GET_SYSTEM_CONFIG: () => ({method: 'GET', route: `/systems/@me/settings`}),
-		PATCH_SYSTEM_CONFIG: () => ({method: 'PATCH', route: `/systems/@me/settings`}),
+		GET_SYSTEM_CONFIG: () => ({
+			method: 'GET',
+			route: `/systems/@me/settings`,
+		}),
+		PATCH_SYSTEM_CONFIG: () => ({
+			method: 'PATCH',
+			route: `/systems/@me/settings`,
+		}),
 
-		GET_SYSTEM_GUILD_SETTINGS: (gid: string) => ({method: 'GET', route: `/systems/@me/guilds/${gid}`}),
-		PATCH_SYSTEM_GUILD_SETTINGS: (gid: string) => ({method: 'PATCH', route: `/systems/@me/guilds/${gid}`}),
+		GET_SYSTEM_GUILD_SETTINGS: (gid: string) => ({
+			method: 'GET',
+			route: `/systems/@me/guilds/${gid}`,
+		}),
+		PATCH_SYSTEM_GUILD_SETTINGS: (gid: string) => ({
+			method: 'PATCH',
+			route: `/systems/@me/guilds/${gid}`,
+		}),
 
-		GET_SYSTEM_AUTOPROXY_SETTINGS: (gid: string) => ({method: 'GET', route: `/systems/@me/autoproxy?guild_id=${gid}`}),
-		PATCH_SYSTEM_AUTOPROXY_SETTINGS: (gid: string) => ({method: 'PATCH', route: `/systems/@me/autoproxy?guild_id=${gid}`}),
+		GET_SYSTEM_AUTOPROXY_SETTINGS: (gid: string) => ({
+			method: 'GET',
+			route: `/systems/@me/autoproxy?guild_id=${gid}`,
+		}),
+		PATCH_SYSTEM_AUTOPROXY_SETTINGS: (gid: string) => ({
+			method: 'PATCH',
+			route: `/systems/@me/autoproxy?guild_id=${gid}`,
+		}),
 
-		GET_MEMBER_GUILD_SETTINGS: (mid: string, gid: string) => ({method: 'GET', route: `/members/${mid}/guilds/${gid}`}),
-		PATCH_MEMBER_GUILD_SETTINGS: (mid: string, gid: string) => ({method: 'PATCH', route: `/members/${mid}/guilds/${gid}`}),
+		GET_MEMBER_GUILD_SETTINGS: (mid: string, gid: string) => ({
+			method: 'GET',
+			route: `/members/${mid}/guilds/${gid}`,
+		}),
+		PATCH_MEMBER_GUILD_SETTINGS: (mid: string, gid: string) => ({
+			method: 'PATCH',
+			route: `/members/${mid}/guilds/${gid}`,
+		}),
 
-		GET_MESSAGE: (mid: string) => ({method: 'GET', route: `/messages/${mid}`})
-	}
-}
+		GET_MESSAGE: (mid: string) => ({
+			method: 'GET',
+			route: `/messages/${mid}`,
+		}),
+	},
+};
 
 export default ROUTES;

--- a/lib/structures/apiError.ts
+++ b/lib/structures/apiError.ts
@@ -12,12 +12,12 @@ export default class APIError {
 		this.api = {
 			baseURL: api.base_url,
 			token: api.token,
-			version: api.version
+			version: api.version,
 		};
 		this.status = data.status || '???';
 		this.code = data.data?.code || '???';
-		this.message = data.data?.message || "Unknown error.";
-		this.statusText = data.statusText || "Unknown error.";
+		this.message = data.data?.message || 'Unknown error.';
+		this.statusText = data.statusText || 'Unknown error.';
 		this.headers = data.headers || {};
 	}
 }

--- a/lib/structures/group.ts
+++ b/lib/structures/group.ts
@@ -7,12 +7,12 @@ import { validatePrivacy } from '../utils';
 import Member from './member';
 
 export const enum GroupPrivacyKeys {
-	Name = 			'name_privacy',
-	Description = 	'description_privacy',
-	Icon = 			'icon_privacy',
-	List = 			'list_privacy',
-	Metadata = 		'metadata_privacy',
-	Visibility = 	'visibility',
+	Name = 'name_privacy',
+	Description = 'description_privacy',
+	Icon = 'icon_privacy',
+	List = 'list_privacy',
+	Metadata = 'metadata_privacy',
+	Visibility = 'visibility',
 }
 
 const pKeys = [
@@ -21,8 +21,8 @@ const pKeys = [
 	GroupPrivacyKeys.Icon,
 	GroupPrivacyKeys.List,
 	GroupPrivacyKeys.Metadata,
-	GroupPrivacyKeys.Visibility
-]
+	GroupPrivacyKeys.Visibility,
+];
 
 export interface GroupPrivacy {
 	name_privacy?: string | null;
@@ -34,67 +34,78 @@ export interface GroupPrivacy {
 }
 
 const KEYS: any = {
-	id: { },
-	uuid: { },
-	system: { },
+	id: {},
+	uuid: {},
+	system: {},
 	name: {
 		test: (n: string) => n.length && n.length <= 100,
-		err: "Name must be 100 characters or less",
-		required: true
+		err: 'Name must be 100 characters or less',
+		required: true,
 	},
 	display_name: {
 		test: (n: string) => !n.length || n.length <= 100,
-		err: "Display name must be 100 characters or less"
+		err: 'Display name must be 100 characters or less',
 	},
 	description: {
 		test: (d: string) => !d.length || d.length < 1000,
-		err: "Description must be 1000 characters or less"
+		err: 'Description must be 1000 characters or less',
 	},
 	icon: {
 		test: async (a: string) => {
-			if(!validUrl.isWebUri(a)) return false;
+			if (!validUrl.isWebUri(a)) return false;
 			try {
 				var data = await axios.head(a);
-				if(data.headers["content-type"]?.startsWith("image")) return true;
+				if (data.headers['content-type']?.startsWith('image')) return true;
 				return false;
-			} catch(e) { return false; }
+			} catch (e) {
+				return false;
+			}
 		},
-		err: "Icon URL must be a valid image and less than 256 characters"
+		err: 'Icon URL must be a valid image and less than 256 characters',
 	},
 	banner: {
 		test: async (a: string) => {
-			if(a.length > 256) return false;
-			if(!validUrl.isWebUri(a)) return false;
+			if (a.length > 256) return false;
+			if (!validUrl.isWebUri(a)) return false;
 			try {
 				var data = await axios.head(a);
-				if(data.headers["content-type"]?.startsWith("image")) return true;
+				if (data.headers['content-type']?.startsWith('image')) return true;
 				return false;
-			} catch(e) { return false; }
+			} catch (e) {
+				return false;
+			}
 		},
-		err: "Banner URL must be a valid image and less than 256 characters"
+		err: 'Banner URL must be a valid image and less than 256 characters',
 	},
 	color: {
-		test: (c: string | Instance) => { c = tc(c); return c.isValid() },
-		err: "Color must be a valid hex code",
-		transform: (c: string | Instance) => { c = tc(c); return c.toHex() }
+		test: (c: string | Instance) => {
+			c = tc(c);
+			return c.isValid();
+		},
+		err: 'Color must be a valid hex code',
+		transform: (c: string | Instance) => {
+			c = tc(c);
+			return c.toHex();
+		},
 	},
 	created: {
-		init: (d: string | Date) => new Date(d)
+		init: (d: string | Date) => new Date(d),
 	},
 	members: {
 		transform: (mems: Map<string, Member> | Array<string>) => {
 			var arr = [];
-			if(mems instanceof Map) for(var m of mems.values()) arr.push(m.id ?? m);
-			else arr = mems.map((m: Member | string) => {
-				return m instanceof Member ? m.id : m;
-			});
+			if (mems instanceof Map) for (var m of mems.values()) arr.push(m.id ?? m);
+			else
+				arr = mems.map((m: Member | string) => {
+					return m instanceof Member ? m.id : m;
+				});
 			return arr;
-		}
+		},
 	},
 	privacy: {
-		transform: (o: any) => validatePrivacy(pKeys, o)
-	}
-}
+		transform: (o: any) => validatePrivacy(pKeys, o),
+	},
+};
 
 export interface IGroup {
 	id: string;
@@ -131,46 +142,46 @@ export default class Group implements IGroup {
 
 	constructor(api: API, data: Partial<Group>) {
 		this.#api = api;
-		for(var k in data) {
-			if(KEYS[k]) {
-				if(KEYS[k].init) data[k] = KEYS[k].init(data[k]);
+		for (var k in data) {
+			if (KEYS[k]) {
+				if (KEYS[k].init) data[k] = KEYS[k].init(data[k]);
 				this[k] = data[k];
 			}
 		}
 	}
 
 	async patch(token?: string) {
-		var data = await this.#api.patchGroup({group: this.id, ...this, token});
-		for(var k in data) if(KEYS[k]) this[k] = data[k];
+		var data = await this.#api.patchGroup({ group: this.id, ...this, token });
+		for (var k in data) if (KEYS[k]) this[k] = data[k];
 		return this;
 	}
 
 	async delete(token?: string) {
-		return await this.#api.deleteGroup({group: this.id, token});
+		return await this.#api.deleteGroup({ group: this.id, token });
 	}
 
 	async getMembers(token?: string) {
-		var mems = await this.#api.getGroupMembers({group: this.id, token});
+		var mems = await this.#api.getGroupMembers({ group: this.id, token });
 		this.members = mems;
 		return mems;
 	}
 
 	async addMembers(members: Array<string>, token?: string) {
-		await this.#api.addGroupMembers({group: this.id, members, token});
+		await this.#api.addGroupMembers({ group: this.id, members, token });
 		var mems = await this.getMembers(token);
 		this.members = mems;
 		return mems;
 	}
 
 	async removeMembers(members: Array<string>, token?: string) {
-		await this.#api.removeGroupMembers({group: this.id, members, token});
+		await this.#api.removeGroupMembers({ group: this.id, members, token });
 		var mems = await this.getMembers(token);
 		this.members = mems;
 		return mems;
 	}
 
 	async setMembers(members: Array<string>, token?: string) {
-		await this.#api.setGroupMembers({group: this.id, members, token});
+		await this.#api.setGroupMembers({ group: this.id, members, token });
 		var mems = await this.getMembers(token);
 		this.members = mems;
 		return mems;
@@ -179,29 +190,29 @@ export default class Group implements IGroup {
 	async verify() {
 		var group: Partial<Group> = {};
 		var errors = [];
-		for(var k in KEYS) {
-			if(KEYS[k].required && !this[k]) {
+		for (var k in KEYS) {
+			if (KEYS[k].required && !this[k]) {
 				errors.push(`Key ${k} is required, but wasn't supplied`);
 				continue;
 			}
 
-			if(this[k] == null) {
+			if (this[k] == null) {
 				group[k] = this[k];
 				continue;
 			}
-			if(this[k] == undefined) continue;
+			if (this[k] == undefined) continue;
 
 			var test = true;
-			if(KEYS[k].test) test = await KEYS[k].test(this[k]);
-			if(!test) {
+			if (KEYS[k].test) test = await KEYS[k].test(this[k]);
+			if (!test) {
 				errors.push(KEYS[k].err);
 				continue;
 			}
-			if(KEYS[k].transform) this[k] = KEYS[k].transform(this[k]);
+			if (KEYS[k].transform) this[k] = KEYS[k].transform(this[k]);
 			group[k] = this[k];
 		}
 
-		if(errors.length) throw new Error(errors.join("\n"));
+		if (errors.length) throw new Error(errors.join('\n'));
 
 		return group;
 	}

--- a/lib/structures/member.ts
+++ b/lib/structures/member.ts
@@ -7,40 +7,37 @@ import tc, { Instance } from 'tinycolor2';
 import validUrl from 'valid-url';
 import axios from 'axios';
 import * as chrono from 'chrono-node';
-import {
-	validatePrivacy,
-	formatDate
-} from '../utils';
+import { validatePrivacy, formatDate } from '../utils';
 
 const parser = chrono.casual.clone();
 parser.refiners.push({
 	refine: (ctx, res) => {
-		res.forEach(r => {
-			if(!r.start.isCertain('year')) r.start.assign('year', 2004)
-		})
+		res.forEach((r) => {
+			if (!r.start.isCertain('year')) r.start.assign('year', 2004);
+		});
 
 		return res;
-	}
-})
+	},
+});
 
 function hasKeys(obj: any, keys: Array<string>) {
-	if(typeof obj !== "object") return false;
+	if (typeof obj !== 'object') return false;
 	var okeys = Object.keys(obj);
 
-	for(var k of keys) if(!okeys.includes(k)) return false;
+	for (var k of keys) if (!okeys.includes(k)) return false;
 
 	return true;
 }
 
 const enum MemberPrivacyKeys {
-	Visibility = 	'visibility',
-	Name = 			'name_privacy',
-	Description = 	'description_privacy',
-	Birthday = 		'birthday_privacy',
-	Pronouns = 		'pronoun_privacy',
-	Avatar = 		'avatar_privacy',
-	Metadata = 		'metadata_privacy',
-	Proxy = 		'proxy_privacy'
+	Visibility = 'visibility',
+	Name = 'name_privacy',
+	Description = 'description_privacy',
+	Birthday = 'birthday_privacy',
+	Pronouns = 'pronoun_privacy',
+	Avatar = 'avatar_privacy',
+	Metadata = 'metadata_privacy',
+	Proxy = 'proxy_privacy',
 }
 
 const pKeys = [
@@ -51,8 +48,8 @@ const pKeys = [
 	MemberPrivacyKeys.Pronouns,
 	MemberPrivacyKeys.Avatar,
 	MemberPrivacyKeys.Metadata,
-	MemberPrivacyKeys.Proxy
-]
+	MemberPrivacyKeys.Proxy,
+];
 
 export interface MemberPrivacy {
 	visibility?: string | null;
@@ -66,109 +63,127 @@ export interface MemberPrivacy {
 }
 
 const KEYS: any = {
-	id: { },
-	uuid: { },
-	system: { },
+	id: {},
+	uuid: {},
+	system: {},
 	name: {
 		test: (n: string) => n.length && n.length <= 100,
-		err: "Name must be 100 characters or less",
-		required: true
+		err: 'Name must be 100 characters or less',
+		required: true,
 	},
 	display_name: {
 		test: (d: string) => !d.length || d.length <= 100,
-		err: "Display name must be 100 characters or less"
+		err: 'Display name must be 100 characters or less',
 	},
 	color: {
-		test: (c: string | Instance) => { c = tc(c); return c.isValid() },
-		err: "Color must be a valid hex code",
-		transform: (c: string | Instance) => { c = tc(c); return c.toHex() }
+		test: (c: string | Instance) => {
+			c = tc(c);
+			return c.isValid();
+		},
+		err: 'Color must be a valid hex code',
+		transform: (c: string | Instance) => {
+			c = tc(c);
+			return c.toHex();
+		},
 	},
 	birthday: {
 		test: (d: string | Date) => {
-			if(d instanceof Date) return true;
+			if (d instanceof Date) return true;
 			else {
 				var d2 = parser.parseDate(d);
-				return d2 && !isNaN(d2.valueOf())
+				return d2 && !isNaN(d2.valueOf());
 			}
 		},
-		err: "Birthday must be a valid date",
+		err: 'Birthday must be a valid date',
 		transform: (d: string | Date) => {
-			if(!d) return d;
+			if (!d) return d;
 			var date;
-			if(!(d instanceof Date)) date = parser.parseDate(d);
+			if (!(d instanceof Date)) date = parser.parseDate(d);
 			else date = d;
 			return formatDate(date!);
 		},
-		init: (d: string | Date) => d ? new Date(d) : d
+		init: (d: string | Date) => (d ? new Date(d) : d),
 	},
 	pronouns: {
 		test: (p: string) => !p.length || p.length <= 100,
-		err: "Pronouns must be 100 characters or less"
+		err: 'Pronouns must be 100 characters or less',
 	},
 	avatar_url: {
 		test: async (a: string) => {
-			if(!validUrl.isWebUri(a)) return false;
+			if (!validUrl.isWebUri(a)) return false;
 			try {
 				var data = await axios.head(a);
-				if(data.headers["content-type"]?.startsWith("image")) return true;
+				if (data.headers['content-type']?.startsWith('image')) return true;
 				return false;
-			} catch(e) { return false; }
+			} catch (e) {
+				return false;
+			}
 		},
-		err: "Avatar URL must be a valid image and less than 256 characters"
+		err: 'Avatar URL must be a valid image and less than 256 characters',
 	},
 	webhook_avatar_url: {
 		test: async (a: string) => {
-			if(!validUrl.isWebUri(a)) return false;
+			if (!validUrl.isWebUri(a)) return false;
 			try {
 				var data = await axios.head(a);
-				if(data.headers["content-type"]?.startsWith("image")) return true;
+				if (data.headers['content-type']?.startsWith('image')) return true;
 				return false;
-			} catch(e) { return false; }
+			} catch (e) {
+				return false;
+			}
 		},
-		err: "Webhook avatar URL must be a valid image and less than 256 characters"
+		err: 'Webhook avatar URL must be a valid image and less than 256 characters',
 	},
 	banner: {
 		test: async (a: string) => {
-			if(!validUrl.isWebUri(a)) return false;
+			if (!validUrl.isWebUri(a)) return false;
 			try {
 				var data = await axios.head(a);
-				if(data.headers["content-type"]?.startsWith("image")) return true;
+				if (data.headers['content-type']?.startsWith('image')) return true;
 				return false;
-			} catch(e) { return false; }
+			} catch (e) {
+				return false;
+			}
 		},
-		err: "Banner URL must be a valid image and less than 256 characters"
+		err: 'Banner URL must be a valid image and less than 256 characters',
 	},
 	description: {
 		test: (d: string) => !d.length || d.length < 1000,
-		err: "Description must be 1000 characters or less"
+		err: 'Description must be 1000 characters or less',
 	},
 	created: {
-		init: (d: string | Date) => new Date(d)
+		init: (d: string | Date) => new Date(d),
 	},
 	proxy_tags: {
-		test: (p: ProxyTag[]) => Array.isArray(p) && !p.some(t => !hasKeys(t, ['prefix', 'suffix']) || `${t.prefix}text${t.suffix}`.length > 100),
-		err: "Proxy tags must be an array of objects containing 'prefix' and 'suffix' keys, and the combined prefix + 'text' + suffix must be less than 100 characters"
+		test: (p: ProxyTag[]) =>
+			Array.isArray(p) &&
+			!p.some(
+				(t) =>
+					!hasKeys(t, ['prefix', 'suffix']) ||
+					`${t.prefix}text${t.suffix}`.length > 100,
+			),
+		err: "Proxy tags must be an array of objects containing 'prefix' and 'suffix' keys, and the combined prefix + 'text' + suffix must be less than 100 characters",
 	},
 	keep_proxy: {
-		test: (v: any) => typeof v == "boolean",
-		err: "Keep proxy must be a boolean (true or false)"
+		test: (v: any) => typeof v == 'boolean',
+		err: 'Keep proxy must be a boolean (true or false)',
 	},
 	tts: {
-		test: (v: any) => typeof v == "boolean",
-		err: "TTS must be a boolean (true or false)"
+		test: (v: any) => typeof v == 'boolean',
+		err: 'TTS must be a boolean (true or false)',
 	},
 	autoproxy_enabled: {
-		test: (v: any) => typeof v == "boolean",
-		err: "Autoproxy status must be a boolean (true or false)"
+		test: (v: any) => typeof v == 'boolean',
+		err: 'Autoproxy status must be a boolean (true or false)',
 	},
-	message_count: { },
+	message_count: {},
 	last_message_timestamp: {
-		init: (d: string | Date) => d ? new Date(d) : d
+		init: (d: string | Date) => (d ? new Date(d) : d),
 	},
 	privacy: {
-		transform: (o: Partial<MemberPrivacy>) => validatePrivacy(pKeys, o)
-	}
-}
+		transform: (o: Partial<MemberPrivacy>) => validatePrivacy(pKeys, o),
+	},
+};
 
 export interface ProxyTag {
 	prefix?: string;
@@ -232,54 +247,58 @@ export default class Member implements IMember {
 
 	constructor(api: API, data: Partial<Member>) {
 		this.#api = api;
-		for(var k in data) {
-			if(KEYS[k]) {
-				if(KEYS[k].init) data[k] = KEYS[k].init(data[k]);
+		for (var k in data) {
+			if (KEYS[k]) {
+				if (KEYS[k].init) data[k] = KEYS[k].init(data[k]);
 				this[k] = data[k];
 			}
 		}
 	}
 
 	async patch(token?: string) {
-		var data = await this.#api.patchMember({member: this.id, ...this, token});
-		for(var k in data) if(KEYS[k]) this[k] = data[k];
+		var data = await this.#api.patchMember({ member: this.id, ...this, token });
+		for (var k in data) if (KEYS[k]) this[k] = data[k];
 		return this;
 	}
 
 	async delete(token?: string) {
-		return await this.#api.deleteMember({member: this.id, token});
+		return await this.#api.deleteMember({ member: this.id, token });
 	}
 
 	async getGroups(token?: string) {
-		var groups = await this.#api.getMemberGroups({member: this.id, token});
+		var groups = await this.#api.getMemberGroups({ member: this.id, token });
 		this.groups = groups;
 		return groups;
 	}
 
 	async addGroups(groups: Array<string>, token?: string) {
-		await this.#api.addMemberGroups({member: this.id, groups, token});
+		await this.#api.addMemberGroups({ member: this.id, groups, token });
 		var grps = await this.getGroups(token);
 		this.groups = grps;
 		return grps;
 	}
 
 	async removeGroups(groups: Array<string>, token?: string) {
-		await this.#api.removeMemberGroups({member: this.id, groups, token});
+		await this.#api.removeMemberGroups({ member: this.id, groups, token });
 		var grps = await this.getGroups(token);
 		this.groups = grps;
 		return grps;
 	}
 
 	async setGroups(groups: Array<string>, token?: string) {
-		await this.#api.setMemberGroups({member: this.id, groups, token});
+		await this.#api.setMemberGroups({ member: this.id, groups, token });
 		var grps = await this.getGroups(token);
 		this.groups = grps;
 		return grps;
 	}
 
 	async getGuildSettings(guild: string, token?: string) {
-		var settings = await this.#api.getMemberGuildSettings({member: this.id, guild, token});
-		if(!this.settings) this.settings = new Map();
+		var settings = await this.#api.getMemberGuildSettings({
+			member: this.id,
+			guild,
+			token,
+		});
+		if (!this.settings) this.settings = new Map();
 		this.settings.set(guild, settings);
 		return settings;
 	}
@@ -287,28 +306,28 @@ export default class Member implements IMember {
 	async verify() {
 		var mem: Partial<Member> = {};
 		var errors = [];
-		for(var k in KEYS) {
-			if(KEYS[k].required && !this[k]) {
+		for (var k in KEYS) {
+			if (KEYS[k].required && !this[k]) {
 				errors.push(`Key ${k} is required, but wasn't supplied`);
 				continue;
 			}
 
-			if(this[k] == null) {
+			if (this[k] == null) {
 				mem[k] = this[k];
 				continue;
 			}
-			if(this[k] == undefined) continue;
+			if (this[k] == undefined) continue;
 
 			var test = true;
-			if(KEYS[k].test) test = await KEYS[k].test(this[k]);
-			if(!test) {
+			if (KEYS[k].test) test = await KEYS[k].test(this[k]);
+			if (!test) {
 				errors.push(KEYS[k].err);
 			}
-			if(KEYS[k].transform) this[k] = KEYS[k].transform(this[k]);
+			if (KEYS[k].transform) this[k] = KEYS[k].transform(this[k]);
 			mem[k] = this[k];
 		}
 
-		if(errors.length) throw new Error(errors.join("\n"));
+		if (errors.length) throw new Error(errors.join('\n'));
 
 		return mem;
 	}

--- a/lib/structures/memberGuildSettings.ts
+++ b/lib/structures/memberGuildSettings.ts
@@ -4,27 +4,29 @@ import axios from 'axios';
 import validUrl from 'valid-url';
 
 const KEYS: any = {
-	guild: { },
-	member: { },
+	guild: {},
+	member: {},
 	display_name: {
 		test: (s: string) => s.length <= 100,
-		err: 'Display name must be 100 characters or less'
+		err: 'Display name must be 100 characters or less',
 	},
 	avatar_url: {
 		test: async (a: string) => {
-			if(!validUrl.isWebUri(a)) return false;
+			if (!validUrl.isWebUri(a)) return false;
 			try {
 				var data = await axios.head(a);
-				if(data.headers["content-type"]?.startsWith("image")) return true;
+				if (data.headers['content-type']?.startsWith('image')) return true;
 				return false;
-			} catch(e) { return false; }
+			} catch (e) {
+				return false;
+			}
 		},
-		err: "Avatar URL must be a valid image and less than 256 characters"
+		err: 'Avatar URL must be a valid image and less than 256 characters',
 	},
 	keep_proxy: {
-		transform: (v?: any) => v ? true : false
-	}
-}
+		transform: (v?: any) => (v ? true : false),
+	},
+};
 
 export interface IMemberGuildSettings {
 	[key: string]: any;
@@ -48,41 +50,41 @@ export default class MemberGuildSettings implements IMemberGuildSettings {
 
 	constructor(api: API, data: Partial<MemberGuildSettings>) {
 		this.#api = api;
-		for(var k in data) {
-			if(KEYS[k]) {
-				if(KEYS[k].init) data[k] = KEYS[k].init(data[k]);
+		for (var k in data) {
+			if (KEYS[k]) {
+				if (KEYS[k].init) data[k] = KEYS[k].init(data[k]);
 				this[k] = data[k];
 			}
 		}
 	}
 
 	async patch(token?: string) {
-		var data = await this.#api.patchMemberGuildSettings({...this, token});
-		for(var k in data) if(KEYS[k]) this[k] = data[k];
+		var data = await this.#api.patchMemberGuildSettings({ ...this, token });
+		for (var k in data) if (KEYS[k]) this[k] = data[k];
 		return this;
 	}
 
 	async verify() {
 		var settings: Partial<MemberGuildSettings> = {};
 		var errors = [];
-		for(var k in KEYS) {
+		for (var k in KEYS) {
 			var test = true;
-			if(this[k] == null) {
+			if (this[k] == null) {
 				settings[k] = this[k];
 				continue;
 			}
-			if(this[k] == undefined) continue;
+			if (this[k] == undefined) continue;
 
-			if(KEYS[k].test) test = await KEYS[k].test(this[k]);
-			if(!test) {
+			if (KEYS[k].test) test = await KEYS[k].test(this[k]);
+			if (!test) {
 				errors.push(KEYS[k].err);
 				continue;
 			}
-			if(KEYS[k].transform) this[k] = KEYS[k].transform(this[k]);
+			if (KEYS[k].transform) this[k] = KEYS[k].transform(this[k]);
 			settings[k] = this[k];
 		}
 
-		if(errors.length) throw new Error(errors.join("\n"));
+		if (errors.length) throw new Error(errors.join('\n'));
 
 		return settings;
 	}

--- a/lib/structures/message.ts
+++ b/lib/structures/message.ts
@@ -1,24 +1,24 @@
 import API from '../index';
 
-import Member from "./member";
-import System from "./system";
+import Member from './member';
+import System from './system';
 
 const KEYS: any = {
 	timestamp: {
-		init: (t: Date | string) => new Date(t)
+		init: (t: Date | string) => new Date(t),
 	},
-	id: { },
-	original: { },
-	sender: { },
-	channel: { },
-	guild: { },
+	id: {},
+	original: {},
+	sender: {},
+	channel: {},
+	guild: {},
 	system: {
-		init: (s: Partial<System>, api: API) => s ? new System(api, s) : null
+		init: (s: Partial<System>, api: API) => (s ? new System(api, s) : null),
 	},
 	member: {
-		init: (m: Partial<Member>, api: API) => m ? new Member(api, m) : null
-	}
-}
+		init: (m: Partial<Member>, api: API) => (m ? new Member(api, m) : null),
+	},
+};
 
 export interface IMessage {
 	timestamp: Date | string;
@@ -47,9 +47,9 @@ export default class Message implements IMessage {
 
 	constructor(api: API, data: Partial<Message>) {
 		this.#api = api;
-		for(var k in data) {
-			if(KEYS[k]) {
-				if(KEYS[k].init) data[k] = KEYS[k].init(data[k]);
+		for (var k in data) {
+			if (KEYS[k]) {
+				if (KEYS[k].init) data[k] = KEYS[k].init(data[k]);
 				this[k] = data[k];
 			}
 		}

--- a/lib/structures/switch.ts
+++ b/lib/structures/switch.ts
@@ -1,9 +1,9 @@
 import API from '../index';
 
-import Member from "./member";
+import Member from './member';
 
 const KEYS: any = {
-	id: { },
+	id: {},
 	timestamp: {
 		init: (t: Date | string) => new Date(t),
 		// transform: (d) => d.toISOString()
@@ -11,14 +11,15 @@ const KEYS: any = {
 	members: {
 		transform: (mems: Map<string, Member> | Array<string>) => {
 			var arr = [];
-			if(mems instanceof Map) for(var m of mems.values()) arr.push(m.id ?? m);
-			else arr = mems.map((m: Member | string) => {
-				return m instanceof Member ? m.id : m;
-			});
+			if (mems instanceof Map) for (var m of mems.values()) arr.push(m.id ?? m);
+			else
+				arr = mems.map((m: Member | string) => {
+					return m instanceof Member ? m.id : m;
+				});
 			return arr;
-		}
-	}
-}
+		},
+	},
+};
 
 export interface ISwitch {
 	id: string;
@@ -37,53 +38,61 @@ export default class Switch implements ISwitch {
 
 	constructor(api: API, data: Partial<Switch>) {
 		this.#api = api;
-		if(!data.timestamp || !data.members)
-			throw new Error("Switch objects require a timestamp and members key");
+		if (!data.timestamp || !data.members)
+			throw new Error('Switch objects require a timestamp and members key');
 
-		for(var k in data) {
-			if(KEYS[k]) {
-				if(KEYS[k].init) data[k] = KEYS[k].init(data[k]);
+		for (var k in data) {
+			if (KEYS[k]) {
+				if (KEYS[k].init) data[k] = KEYS[k].init(data[k]);
 				this[k] = data[k];
 			}
 		}
 	}
 
 	async patchTimestamp(timestamp: Date, token?: string) {
-		var data = await this.#api.patchSwitchTimestamp({switch: this.id, timestamp, token});
-		for(var k in data) if(KEYS[k]) this[k] = data[k];
+		var data = await this.#api.patchSwitchTimestamp({
+			switch: this.id,
+			timestamp,
+			token,
+		});
+		for (var k in data) if (KEYS[k]) this[k] = data[k];
 		return this;
 	}
 
 	async patchMembers(token?: string, members?: Array<string>) {
-		var data = await this.#api.patchSwitchMembers({switch: this.id, members, token});
-		for(var k in data) if(KEYS[k]) this[k] = data[k];
+		var data = await this.#api.patchSwitchMembers({
+			switch: this.id,
+			members,
+			token,
+		});
+		for (var k in data) if (KEYS[k]) this[k] = data[k];
 		return this;
 	}
 
 	async delete(token?: string) {
-		return await this.#api.deleteSwitch({switch: this.id, token});
+		return await this.#api.deleteSwitch({ switch: this.id, token });
 	}
 
 	async verify() {
 		var sw: Partial<Switch> = {};
 		var errors = [];
-		for(var k in KEYS) {
-			if(this[k] == null) {
+		for (var k in KEYS) {
+			if (this[k] == null) {
 				sw[k] = this[k];
 				continue;
 			}
-			if(this[k] == undefined) continue;
+			if (this[k] == undefined) continue;
 
 			var test = true;
-			if(KEYS[k].test) test = await KEYS[k].test(this[k]);
-			if(!test) {
+			if (KEYS[k].test) test = await KEYS[k].test(this[k]);
+			if (!test) {
 				errors.push(KEYS[k].err);
 			}
-			if(KEYS[k].transform) this[k] = KEYS[k].transform(this[k]);
+			if (KEYS[k].transform) this[k] = KEYS[k].transform(this[k]);
 			sw[k] = this[k];
 		}
 
-		if(errors.length) throw new Error(errors.join("\n"));
+		if (errors.length) throw new Error(errors.join('\n'));
 
 		return sw;
 	}

--- a/lib/structures/system.ts
+++ b/lib/structures/system.ts
@@ -13,12 +13,12 @@ import SystemGuildSettings from './systemGuildSettings';
 import SystemAutoproxyConfig from './systemAutoproxySettings';
 
 export const enum SystemPrivacyKeys {
-	Description = 	'description_privacy',
-	Pronouns = 		'pronoun_privacy',
-	MemberList = 	'member_list_privacy',
-	GroupList = 	'group_list_privacy',
-	Front = 		'front_privacy',
-	FrontHistory = 	'front_history_privacy'
+	Description = 'description_privacy',
+	Pronouns = 'pronoun_privacy',
+	MemberList = 'member_list_privacy',
+	GroupList = 'group_list_privacy',
+	Front = 'front_privacy',
+	FrontHistory = 'front_history_privacy',
 }
 
 const pKeys = [
@@ -27,8 +27,8 @@ const pKeys = [
 	SystemPrivacyKeys.MemberList,
 	SystemPrivacyKeys.GroupList,
 	SystemPrivacyKeys.Front,
-	SystemPrivacyKeys.FrontHistory
-]
+	SystemPrivacyKeys.FrontHistory,
+];
 
 export interface SystemPrivacy {
 	description_privacy?: string;
@@ -40,52 +40,62 @@ export interface SystemPrivacy {
 }
 
 const KEYS: any = {
-	id: { },
-	uuid: { },
+	id: {},
+	uuid: {},
 	name: {
 		test: (n: string) => !n.length || n.length <= 100,
-		err: "Name must be 100 characters or less"
+		err: 'Name must be 100 characters or less',
 	},
 	description: {
 		test: (d: string) => !d.length || d.length < 1000,
-		err: "Description must be 1000 characters or less"
+		err: 'Description must be 1000 characters or less',
 	},
-	tag: { },
-	pronouns: { },
+	tag: {},
+	pronouns: {},
 	avatar_url: {
 		test: async (a: string) => {
-			if(!validUrl.isWebUri(a)) return false;
+			if (!validUrl.isWebUri(a)) return false;
 			try {
 				var data = await axios.head(a);
-				if(data.headers["content-type"]?.startsWith("image")) return true;
+				if (data.headers['content-type']?.startsWith('image')) return true;
 				return false;
-			} catch(e) { return false; }
+			} catch (e) {
+				return false;
+			}
 		},
-		err: "Avatar URL must be a valid image and less than 256 characters"
+		err: 'Avatar URL must be a valid image and less than 256 characters',
 	},
 	banner: {
 		test: async (a: string) => {
-			if(!validUrl.isWebUri(a)) return false;
+			if (!validUrl.isWebUri(a)) return false;
 			try {
 				var data = await axios.head(a);
-				if(data.headers["content-type"]?.startsWith("image")) return true;
+				if (data.headers['content-type']?.startsWith('image')) return true;
 				return false;
-			} catch(e) { return false; }
+			} catch (e) {
+				return false;
+			}
 		},
-		err: "Banner URL must be a valid image and less than 256 characters"
+		err: 'Banner URL must be a valid image and less than 256 characters',
 	},
 	color: {
-		test: (c: string | Instance) => { c = tc(c); return c.isValid() },
-		err: "Color must be a valid hex code",
-		transform: (c: string | Instance) => { c = tc(c); return c.toHex() }
+		test: (c: string | Instance) => {
+			c = tc(c);
+			return c.isValid();
+		},
+		err: 'Color must be a valid hex code',
+		transform: (c: string | Instance) => {
+			c = tc(c);
+			return c.toHex();
+		},
 	},
 	created: {
-		init: (d: Date | string) => new Date(d)
+		init: (d: Date | string) => new Date(d),
 	},
 	privacy: {
-		transform: (o: Partial<SystemPrivacy>) => validatePrivacy(pKeys, o)
-	}
-}
+		transform: (o: Partial<SystemPrivacy>) => validatePrivacy(pKeys, o),
+	},
+};
 
 export interface ISystem {
 	id: string;
@@ -136,69 +146,78 @@ export default class System implements ISystem {
 
 	constructor(api: API, data: Partial<System>) {
 		this.#api = api;
-		for(var k in data) {
-			if(KEYS[k]) {
-				if(KEYS[k].init) data[k] = KEYS[k].init(data[k]);
+		for (var k in data) {
+			if (KEYS[k]) {
+				if (KEYS[k].init) data[k] = KEYS[k].init(data[k]);
 				this[k] = data[k];
 			}
 		}
 	}
 
 	async patch(token?: string) {
-		var data = await this.#api.patchSystem({system: this.id, ...this, token});
-		for(var k in data) if(KEYS[k]) this[k] = data[k];
+		var data = await this.#api.patchSystem({ system: this.id, ...this, token });
+		for (var k in data) if (KEYS[k]) this[k] = data[k];
 		return this;
 	}
 
 	async createMember(data: Partial<Member>) {
 		var mem = await this.#api.createMember(data);
-		if(!this.members) this.members = new Map();
+		if (!this.members) this.members = new Map();
 		this.members.set(mem.id, mem);
 		return mem;
 	}
 
 	async getMember(member: string, token?: string) {
-		var mem = await this.#api.getMember({member, token});
-		if(!this.members) this.members = new Map();
+		var mem = await this.#api.getMember({ member, token });
+		if (!this.members) this.members = new Map();
 		this.members.set(mem.id, mem);
 		return mem;
 	}
 
 	async getMembers(token?: string) {
-		var mems = await this.#api.getMembers({system: this.id, token});
+		var mems = await this.#api.getMembers({ system: this.id, token });
 		this.members = mems;
 		return mems;
 	}
 
 	async deleteMember(member: string, token?: string) {
-		await this.#api.deleteMember({member, token});
-		if(this.members) this.members.delete(member);
+		await this.#api.deleteMember({ member, token });
+		if (this.members) this.members.delete(member);
 		return;
 	}
 
 	async createGroup(data: Partial<Group>) {
 		var group = await this.#api.createGroup(data);
-		if(!this.groups) this.groups = new Map();
+		if (!this.groups) this.groups = new Map();
 		this.groups.set(group.id, group);
 		return group;
 	}
 
-	async getGroups(token?: string, with_members: boolean = false, raw: boolean = false) {
-		var groups = await this.#api.getGroups({system: this.id, with_members, raw, token});
+	async getGroups(
+		token?: string,
+		with_members: boolean = false,
+		raw: boolean = false,
+	) {
+		var groups = await this.#api.getGroups({
+			system: this.id,
+			with_members,
+			raw,
+			token,
+		});
 		this.groups = groups;
 		return groups;
 	}
 
 	async getGroup(group: string, token?: string) {
-		var grp = await this.#api.getGroup({group, token});
-		if(!this.groups) this.groups = new Map<string, Group>();
-		this.groups.set(grp.id, grp)
+		var grp = await this.#api.getGroup({ group, token });
+		if (!this.groups) this.groups = new Map<string, Group>();
+		this.groups.set(grp.id, grp);
 		return grp;
 	}
 
 	async deleteGroup(group: string, token?: string) {
-		await this.#api.deleteGroup({group, token});
-		if(this.groups) this.groups.delete(group);
+		await this.#api.deleteGroup({ group, token });
+		if (this.groups) this.groups.delete(group);
 		return;
 	}
 
@@ -206,40 +225,51 @@ export default class System implements ISystem {
 		return this.#api.createSwitch(data);
 	}
 
-	async getSwitches(token?: string, raw: boolean = false, before?: Date, limit: number = 100) {
-		var switches = await this.#api.getSwitches({system: this.id, token, raw, before, limit});
+	async getSwitches(
+		token?: string,
+		raw: boolean = false,
+		before?: Date,
+		limit: number = 100,
+	) {
+		var switches = await this.#api.getSwitches({
+			system: this.id,
+			token,
+			raw,
+			before,
+			limit,
+		});
 		this.switches = switches;
 		return switches;
 	}
 
 	async getFronters(token?: string) {
-		var fronters = await this.#api.getFronters({system: this.id, token})
+		var fronters = await this.#api.getFronters({ system: this.id, token });
 		this.fronters = fronters;
 		return fronters;
 	}
 
 	async deleteSwitch(switchid: string, token?: string) {
-		await this.#api.deleteSwitch({switch: switchid, token});
-		if(this.switches) this.switches.delete(switchid);
+		await this.#api.deleteSwitch({ switch: switchid, token });
+		if (this.switches) this.switches.delete(switchid);
 		return;
 	}
 
 	async getConfig(token?: string) {
-		var settings = await this.#api.getSystemConfig({token});
+		var settings = await this.#api.getSystemConfig({ token });
 		this.config = settings;
 		return settings;
 	}
 
 	async getGuildSettings(guild: string, token?: string) {
-		var settings = await this.#api.getSystemGuildSettings({guild, token});
-		if(!this.settings) this.settings = new Map();
+		var settings = await this.#api.getSystemGuildSettings({ guild, token });
+		if (!this.settings) this.settings = new Map();
 		this.settings.set(guild, settings);
 		return settings;
 	}
 
 	async getAutoproxySettings(guild: string, token?: string) {
-		var settings = await this.#api.getSystemAutoproxySettings({guild, token});
-		if(!this.autoproxySettings) this.autoproxySettings = new Map();
+		var settings = await this.#api.getSystemAutoproxySettings({ guild, token });
+		if (!this.autoproxySettings) this.autoproxySettings = new Map();
 		this.autoproxySettings.set(guild, settings);
 		return settings;
 	}
@@ -247,24 +277,24 @@ export default class System implements ISystem {
 	async verify() {
 		var sys: Partial<System> = {};
 		var errors = [];
-		for(var k in KEYS) {
+		for (var k in KEYS) {
 			var test = true;
-			if(this[k] == null) {
+			if (this[k] == null) {
 				sys[k] = this[k];
 				continue;
 			}
-			if(this[k] == undefined) continue;
+			if (this[k] == undefined) continue;
 
-			if(KEYS[k].test) test = await KEYS[k].test(this[k]);
-			if(!test) {
+			if (KEYS[k].test) test = await KEYS[k].test(this[k]);
+			if (!test) {
 				errors.push(KEYS[k].err);
 				continue;
 			}
-			if(KEYS[k].transform) this[k] = KEYS[k].transform(this[k]);
+			if (KEYS[k].transform) this[k] = KEYS[k].transform(this[k]);
 			sys[k] = this[k];
 		}
 
-		if(errors.length) throw new Error(errors.join("\n"));
+		if (errors.length) throw new Error(errors.join('\n'));
 
 		return sys;
 	}

--- a/lib/structures/systemAutoproxySettings.ts
+++ b/lib/structures/systemAutoproxySettings.ts
@@ -4,27 +4,27 @@ export enum AutoProxyModes {
 	Off = 'off',
 	Front = 'front',
 	Latch = 'latch',
-	Member = 'member'
+	Member = 'member',
 }
 
 const apVals: string[] = [
 	AutoProxyModes.Off,
 	AutoProxyModes.Front,
 	AutoProxyModes.Latch,
-	AutoProxyModes.Member
-]
+	AutoProxyModes.Member,
+];
 
 const KEYS: any = {
-	guild: { },
+	guild: {},
 	autoproxy_mode: {
 		test: (s?: string) => s && apVals.includes(s),
-		err: `Invalid mode provided. Valid autoproxy mode values: ${apVals.join(", ")}`
+		err: `Invalid mode provided. Valid autoproxy mode values: ${apVals.join(', ')}`,
 	},
-	autoproxy_member: { },
+	autoproxy_member: {},
 	last_latch_timestamp: {
-		init: (d: Date | string) => d ? new Date(d) : d
-	}
-}
+		init: (d: Date | string) => (d ? new Date(d) : d),
+	},
+};
 
 export interface ISystemAutoproxySettings {
 	guild: string;
@@ -33,7 +33,9 @@ export interface ISystemAutoproxySettings {
 	last_latch_timestamp?: Date;
 }
 
-export default class SystemAutoproxySettings implements ISystemAutoproxySettings {
+export default class SystemAutoproxySettings
+	implements ISystemAutoproxySettings
+{
 	[key: string]: any;
 
 	#api: API;
@@ -43,46 +45,48 @@ export default class SystemAutoproxySettings implements ISystemAutoproxySettings
 	autoproxy_member?: string | null;
 	last_latch_timestamp?: Date;
 
-	constructor(api: API, data: Partial<SystemAutoproxySettings> = { }) {
+	constructor(api: API, data: Partial<SystemAutoproxySettings> = {}) {
 		this.#api = api;
-		for(var k in data) {
-			if(KEYS[k]) {
-				if(KEYS[k].init) data[k] = KEYS[k].init(data[k]);
+		for (var k in data) {
+			if (KEYS[k]) {
+				if (KEYS[k].init) data[k] = KEYS[k].init(data[k]);
 				this[k] = data[k];
 			}
 		}
 	}
 
 	async patch(token?: string) {
-		var data = await this.#api.patchSystemAutoproxySettings({...this, token});
-		for(var k in data) if(KEYS[k]) this[k] = data[k];
+		var data = await this.#api.patchSystemAutoproxySettings({ ...this, token });
+		for (var k in data) if (KEYS[k]) this[k] = data[k];
 		return this;
 	}
 
 	async verify() {
 		var settings: Partial<SystemAutoproxySettings> = {};
 		var errors = [];
-		for(var k in KEYS) {
+		for (var k in KEYS) {
 			var test = true;
-			if(this[k] == null) {
+			if (this[k] == null) {
 				settings[k] = this[k];
 				continue;
 			}
-			if(this[k] == undefined) continue;
+			if (this[k] == undefined) continue;
 
-			if(KEYS[k].test) test = await KEYS[k].test(this[k]);
-			if(!test) {
+			if (KEYS[k].test) test = await KEYS[k].test(this[k]);
+			if (!test) {
 				errors.push(KEYS[k].err);
 				continue;
 			}
-			if(KEYS[k].transform) this[k] = KEYS[k].transform(this[k]);
+			if (KEYS[k].transform) this[k] = KEYS[k].transform(this[k]);
 			settings[k] = this[k];
 		}
 
-		if(settings.autoproxy_mode == 'member' && !settings.autoproxy_member)
-			errors.push('Autoproxy member MUST be supplied if mode is set to "member"');
+		if (settings.autoproxy_mode == 'member' && !settings.autoproxy_member)
+			errors.push(
+				'Autoproxy member MUST be supplied if mode is set to "member"',
+			);
 
-		if(errors.length) throw new Error(errors.join("\n"));
+		if (errors.length) throw new Error(errors.join('\n'));
 
 		return settings;
 	}

--- a/lib/structures/systemConfig.ts
+++ b/lib/structures/systemConfig.ts
@@ -3,13 +3,13 @@ import API from '../index';
 import { rawTimeZones } from '@vvo/tzdb';
 
 function findTz(t: string) {
-	var raw = rawTimeZones.find(z => {
-		return ([
+	var raw = rawTimeZones.find((z) => {
+		return [
 			z.name.toLowerCase(),
 			z.abbreviation.toLowerCase(),
-			z.alternativeName.toLowerCase()
-		].includes(t.toLowerCase().replace('utc', 'gmt')));
-	})
+			z.alternativeName.toLowerCase(),
+		].includes(t.toLowerCase().replace('utc', 'gmt'));
+	});
 
 	return raw;
 }
@@ -17,30 +17,30 @@ function findTz(t: string) {
 const KEYS: any = {
 	timezone: {
 		test: (t: string) => findTz(t),
-		err: "Timezone must be valid",
+		err: 'Timezone must be valid',
 		transform: (t: string) => {
-			var raw = findTz(t)
-			return raw!.abbreviation.replace('GMT','UTC');
-		}
+			var raw = findTz(t);
+			return raw!.abbreviation.replace('GMT', 'UTC');
+		},
 	},
 	pings_enabled: {
-		transform: (v?: any) => v ? true : false
+		transform: (v?: any) => (v ? true : false),
 	},
 	latch_timeout: {
-		test: (v?: any) => !isNaN(v)
+		test: (v?: any) => !isNaN(v),
 	},
 	member_default_private: {
-		transform: (v?: any) => v ? true : false
+		transform: (v?: any) => (v ? true : false),
 	},
 	group_default_private: {
-		transform: (v?: any) => v ? true : false
+		transform: (v?: any) => (v ? true : false),
 	},
 	show_private_info: {
-		transform: (v?: any) => v ? true : false
+		transform: (v?: any) => (v ? true : false),
 	},
-	member_limit: { },
-	group_limit: { }
-}
+	member_limit: {},
+	group_limit: {},
+};
 
 export interface ISystemConfig {
 	timezone?: string;
@@ -67,43 +67,43 @@ export default class SystemConfig implements ISystemConfig {
 	member_limit?: number;
 	group_limit?: number;
 
-	constructor(api: API, data: Partial<SystemConfig> = { }) {
+	constructor(api: API, data: Partial<SystemConfig> = {}) {
 		this.#api = api;
-		for(var k in data) {
-			if(KEYS[k]) {
-				if(KEYS[k].init) data[k] = KEYS[k].init(data[k]);
+		for (var k in data) {
+			if (KEYS[k]) {
+				if (KEYS[k].init) data[k] = KEYS[k].init(data[k]);
 				this[k] = data[k];
 			}
 		}
 	}
 
 	async patch(token?: string) {
-		var data = await this.#api.patchSystemConfig({...this, token});
-		for(var k in data) if(KEYS[k]) this[k] = data[k];
+		var data = await this.#api.patchSystemConfig({ ...this, token });
+		for (var k in data) if (KEYS[k]) this[k] = data[k];
 		return this;
 	}
 
 	async verify() {
 		var config: Partial<SystemConfig> = {};
 		var errors = [];
-		for(var k in KEYS) {
+		for (var k in KEYS) {
 			var test = true;
-			if(this[k] == null) {
+			if (this[k] == null) {
 				config[k] = this[k];
 				continue;
 			}
-			if(this[k] == undefined) continue;
+			if (this[k] == undefined) continue;
 
-			if(KEYS[k].test) test = await KEYS[k].test(this[k]);
-			if(!test) {
+			if (KEYS[k].test) test = await KEYS[k].test(this[k]);
+			if (!test) {
 				errors.push(KEYS[k].err);
 				continue;
 			}
-			if(KEYS[k].transform) this[k] = KEYS[k].transform(this[k]);
+			if (KEYS[k].transform) this[k] = KEYS[k].transform(this[k]);
 			config[k] = this[k];
 		}
 
-		if(errors.length) throw new Error(errors.join("\n"));
+		if (errors.length) throw new Error(errors.join('\n'));
 
 		return config;
 	}

--- a/lib/structures/systemGuildSettings.ts
+++ b/lib/structures/systemGuildSettings.ts
@@ -4,33 +4,35 @@ import axios from 'axios';
 import validUrl from 'valid-url';
 
 const KEYS: any = {
-	guild: { },
+	guild: {},
 	proxying_enabled: {
-		transform: (v?: any) => v ? true : false
+		transform: (v?: any) => (v ? true : false),
 	},
 	tag: {
 		test: (s?: string) => s!.length <= 79,
-		err: 'Server tag must be 79 characters or less'
+		err: 'Server tag must be 79 characters or less',
 	},
 	tag_enabled: {
-		transform: (v?: any) => v ? true : false
+		transform: (v?: any) => (v ? true : false),
 	},
 	avatar_url: {
 		test: async (a: string) => {
-			if(!validUrl.isWebUri(a)) return false;
+			if (!validUrl.isWebUri(a)) return false;
 			try {
 				var data = await axios.head(a);
-				if(data.headers["content-type"]?.startsWith("image")) return true;
+				if (data.headers['content-type']?.startsWith('image')) return true;
 				return false;
-			} catch(e) { return false; }
+			} catch (e) {
+				return false;
+			}
 		},
-		err: "Avatar URL must be a valid image and less than 256 characters"
+		err: 'Avatar URL must be a valid image and less than 256 characters',
 	},
 	display_name: {
 		test: (d: string) => !d.length || d.length <= 100,
-		err: "Display name must be 100 characters or less"
-	}
-}
+		err: 'Display name must be 100 characters or less',
+	},
+};
 
 export interface ISystemGuildSettings {
 	[key: string]: any;
@@ -55,43 +57,43 @@ export default class SystemGuildSettings implements ISystemGuildSettings {
 	avatar_url?: string | null;
 	display_name?: string | null;
 
-	constructor(api: API, data: Partial<SystemGuildSettings> = { }) {
+	constructor(api: API, data: Partial<SystemGuildSettings> = {}) {
 		this.#api = api;
-		for(var k in data) {
-			if(KEYS[k]) {
-				if(KEYS[k].init) data[k] = KEYS[k].init(data[k]);
+		for (var k in data) {
+			if (KEYS[k]) {
+				if (KEYS[k].init) data[k] = KEYS[k].init(data[k]);
 				this[k] = data[k];
 			}
 		}
 	}
 
 	async patch(token?: string) {
-		var data = await this.#api.patchSystemGuildSettings({...this, token});
-		for(var k in data) if(KEYS[k]) this[k] = data[k];
+		var data = await this.#api.patchSystemGuildSettings({ ...this, token });
+		for (var k in data) if (KEYS[k]) this[k] = data[k];
 		return this;
 	}
 
 	async verify() {
 		var settings: Partial<SystemGuildSettings> = {};
 		var errors = [];
-		for(var k in KEYS) {
+		for (var k in KEYS) {
 			var test = true;
-			if(this[k] == null) {
+			if (this[k] == null) {
 				settings[k] = this[k];
 				continue;
 			}
-			if(this[k] == undefined) continue;
+			if (this[k] == undefined) continue;
 
-			if(KEYS[k].test) test = await KEYS[k].test(this[k]);
-			if(!test) {
+			if (KEYS[k].test) test = await KEYS[k].test(this[k]);
+			if (!test) {
 				errors.push(KEYS[k].err);
 				continue;
 			}
-			if(KEYS[k].transform) this[k] = KEYS[k].transform(this[k]);
+			if (KEYS[k].transform) this[k] = KEYS[k].transform(this[k]);
 			settings[k] = this[k];
 		}
 
-		if(errors.length) throw new Error(errors.join("\n"));
+		if (errors.length) throw new Error(errors.join('\n'));
 
 		return settings;
 	}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,8 +1,8 @@
 export function validatePrivacy(keys: Array<string>, obj: any) {
 	var priv: any = {};
-	for(var k of keys) {
-		if(obj[k] == undefined) continue;
-		if(['private', 'public'].includes(obj[k])) {
+	for (var k of keys) {
+		if (obj[k] == undefined) continue;
+		if (['private', 'public'].includes(obj[k])) {
 			priv[k] = obj[k];
 			continue;
 		}
@@ -15,8 +15,8 @@ export function validatePrivacy(keys: Array<string>, obj: any) {
 
 export function formatDate(D: Date) {
 	var y = ('000' + D.getFullYear()).slice(-4);
-	var m = ("0" + (D.getMonth() + 1)).slice(-2);
-	var d = ("0" + (D.getDate())).slice(-2);
+	var m = ('0' + (D.getMonth() + 1)).slice(-2);
+	var d = ('0' + D.getDate()).slice(-2);
 
 	return `${y}-${m}-${d}`;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/valid-url": "^1.0.3",
         "esbuild": "^0.15.15",
         "jest": "^30.0.3",
+        "prettier": "3.6.2",
         "rollup": "^3.4.0",
         "ts-jest": "^29.4.0",
         "tslib": "^2.4.1",
@@ -4249,6 +4250,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "30.0.2",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.2.tgz",
@@ -8035,6 +8052,12 @@
       "requires": {
         "find-up": "^4.0.0"
       }
+    },
+    "prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true
     },
     "pretty-format": {
       "version": "30.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@rollup/plugin-typescript": "^9.0.2",
-        "@types/node": "^18.11.9",
+        "@types/node": "^20.19.7",
         "@types/tinycolor2": "^1.4.3",
         "@types/valid-url": "^1.0.3",
         "esbuild": "^0.15.15",
@@ -26,7 +26,7 @@
         "rollup": "^3.4.0",
         "ts-jest": "^29.4.0",
         "tslib": "^2.4.1",
-        "typescript": "^4.9.3"
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1237,10 +1237,14 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.11.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
-      "dev": true
+      "version": "20.19.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.7.tgz",
+      "integrity": "sha512-1GM9z6BJOv86qkPvzh2i6VW5+VVrXxCLknfmTkWEqz+6DqosiY28XUWCTmBcJ0ACzKqx/iwdIREfo1fwExIlkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -4894,17 +4898,25 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unrs-resolver": {
       "version": "1.9.2",
@@ -6098,10 +6110,13 @@
       }
     },
     "@types/node": {
-      "version": "18.11.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
-      "dev": true
+      "version": "20.19.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.7.tgz",
+      "integrity": "sha512-1GM9z6BJOv86qkPvzh2i6VW5+VVrXxCLknfmTkWEqz+6DqosiY28XUWCTmBcJ0ACzKqx/iwdIREfo1fwExIlkA==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.21.0"
+      }
     },
     "@types/stack-utils": {
       "version": "2.0.3",
@@ -8451,9 +8466,15 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
     "unrs-resolver": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "scripts": {
     "test": "npx jest",
+    "check": "npx tsc --noEmit",
     "lint": "npx prettier lib --check",
     "format": "npx prettier lib --write",
     "build": "npx rollup --config",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   },
   "scripts": {
     "test": "jest",
+    "lint": "npx prettier lib --check",
+    "format": "npx prettier lib --write",
     "build": "npx rollup --config",
     "prepublishOnly": "npm run build"
   },
@@ -51,6 +53,7 @@
     "@types/valid-url": "^1.0.3",
     "esbuild": "^0.15.15",
     "jest": "^30.0.3",
+    "prettier": "3.6.2",
     "rollup": "^3.4.0",
     "ts-jest": "^29.4.0",
     "tslib": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "description": "A JS wrapper for the PluralKit Discord bot's API.",
   "devDependencies": {
     "@rollup/plugin-typescript": "^9.0.2",
-    "@types/node": "^18.11.9",
+    "@types/node": "^20.19.7",
     "@types/tinycolor2": "^1.4.3",
     "@types/valid-url": "^1.0.3",
     "esbuild": "^0.15.15",
@@ -58,6 +58,6 @@
     "rollup": "^3.4.0",
     "ts-jest": "^29.4.0",
     "tslib": "^2.4.1",
-    "typescript": "^4.9.3"
+    "typescript": "^5.8.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "valid-url": "^1.0.9"
   },
   "scripts": {
-    "test": "jest",
+    "test": "npx jest",
     "lint": "npx prettier lib --check",
     "format": "npx prettier lib --write",
     "build": "npx rollup --config",


### PR DESCRIPTION
depends on #17 (and thus also #16)

removes unneeded try-catch statements that just throw the original error again